### PR TITLE
feat : Swagger를 활용한 문서 자동화 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/todoay/api/domain/auth/controller/MailVerificationController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/MailVerificationController.java
@@ -3,6 +3,9 @@ package com.todoay.api.domain.auth.controller;
 import com.todoay.api.domain.auth.dto.EmailDto;
 import com.todoay.api.domain.auth.dto.EmailTokenDto;
 import com.todoay.api.domain.auth.service.MainVerificationService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,11 +20,18 @@ import javax.validation.Valid;
 public class MailVerificationController {
     private final MainVerificationService mainVerificationService;
 
+    @ApiOperation(value = "이메일로 인증 메일은 보낸다.", notes = "입력한 이메일로 인증 메일은 보낸다. 입력한 이메일이 이메일 양식을 지키지 않을 경우 오류 발생.")
+    @ApiResponses({
+            @ApiResponse(code=204, message = "성공"),
+            @ApiResponse(code = 400, message = "올바른 이메일 양식을 입력하지 않음.")
+    })
     @GetMapping("/auth/mail")
     public ResponseEntity<Void> sendVerificationMail(@Valid EmailDto emailDto) {
         mainVerificationService.sendVerificationMail(emailDto);
         return ResponseEntity.noContent().build();
     }
+
+
 
     @PostMapping("/auth/email-verification")
     public ResponseEntity<Void> verifyEmailToken(@RequestBody EmailTokenDto emailTokenDto) {

--- a/src/main/java/com/todoay/api/domain/auth/dto/EmailDto.java
+++ b/src/main/java/com/todoay/api/domain/auth/dto/EmailDto.java
@@ -1,5 +1,6 @@
 package com.todoay.api.domain.auth.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,6 +10,7 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @AllArgsConstructor
 public class EmailDto {
+    @ApiModelProperty(value = "이메일", dataType = "string", required = true )
     @NotBlank
     @Email
     private String email;

--- a/src/main/java/com/todoay/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/todoay/api/global/config/SwaggerConfig.java
@@ -1,0 +1,50 @@
+package com.todoay.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@EnableWebMvc
+@Configuration
+public class SwaggerConfig {
+
+    private static final Set<String> DEFAULT_PRODUCES_CONSUMES = new HashSet<>(Arrays.asList("application/json"));
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.todoay.api"))
+                .build()
+                .apiInfo(apiInfo())
+                .consumes(DEFAULT_PRODUCES_CONSUMES);
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Todoay-Api")
+                .description("Todoay 어플리케이션 API 문서")
+                .version("3.0")
+                .build();
+    }
+
+
+    // @enableWebMvc가 켜져있을 때, /swagger-ui/index.html로 redirect가 되지 않는 경우 발생.
+    @Bean
+    public InternalResourceViewResolver defaultViewResolver() {
+        return new InternalResourceViewResolver();
+    }
+
+
+}

--- a/src/main/java/com/todoay/api/global/controller/SwaggerController.java
+++ b/src/main/java/com/todoay/api/global/controller/SwaggerController.java
@@ -1,0 +1,15 @@
+package com.todoay.api.global.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Slf4j
+@Controller
+public class SwaggerController {
+
+    @GetMapping ("/docs")
+    public String showSwaggerDocs() {
+        return "redirect:/swagger-ui/index.html";
+    }
+}

--- a/src/main/java/com/todoay/api/global/controller/SwaggerController.java
+++ b/src/main/java/com/todoay/api/global/controller/SwaggerController.java
@@ -1,10 +1,10 @@
 package com.todoay.api.global.controller;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import springfox.documentation.annotations.ApiIgnore;
 
-@Slf4j
+@ApiIgnore
 @Controller
 public class SwaggerController {
 


### PR DESCRIPTION
Swagger를 활용해 문서 자동화 기능 작성

- Swagger 문서를 쉽게 보기 위해서 SwaggerController 생성 /docs 로 접근 할 때, swagger 문서로 리다이렉트 시도.
- Swagger 활용을 위한 참고 케이스로 MailVerificationController와 EmailDto에 Swagger 관련 어노테이션 추가

![image](https://user-images.githubusercontent.com/76154390/179335447-af54cfc4-1192-4ef7-a1d2-d49b7e573051.png)
![image](https://user-images.githubusercontent.com/76154390/179335529-e615f2c0-5118-4352-9796-26f18817bd49.png)


