### PR TITLE
feat: 이메일 인증 여부 GET 구현

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/controller/MailVerificationController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/MailVerificationController.java
@@ -2,6 +2,7 @@ package com.todoay.api.domain.auth.controller;
 
 import com.todoay.api.domain.auth.dto.AuthSendEmailRequestDto;
 import com.todoay.api.domain.auth.dto.AuthVerifyEmailTokenOnSingUpDto;
+import com.todoay.api.domain.auth.dto.CheckEmailVerifiedResponseDto;
 import com.todoay.api.domain.auth.service.MailVerificationService;
 import com.todoay.api.domain.profile.exception.EmailNotFoundException;
 import com.todoay.api.global.exception.ErrorResponse;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
@@ -59,5 +61,19 @@ public class MailVerificationController {
             modelAndView.addObject("exception", e.getClass().getSimpleName());
         }
         return modelAndView;
+    }
+
+    @GetMapping("/auth/{email}/email-verified")
+    @Operation(
+            summary = "path variable로 받은 email의 계정의 이메일 인증 여부를 응답한다.",
+            description = "{'emailVerified': boolean}",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = CheckEmailVerifiedResponseDto.class))),
+                    @ApiResponse(responseCode = "400", description = "email에 해당하는 계정이 없는 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    public ResponseEntity<CheckEmailVerifiedResponseDto> checkEmailVerified(@PathVariable String email) {
+        CheckEmailVerifiedResponseDto checkEmailVerifiedResponseDto = mailVerificationService.checkEmailVerified(email);
+        return ResponseEntity.ok(checkEmailVerifiedResponseDto);
     }
 }

--- a/src/main/java/com/todoay/api/domain/auth/dto/CheckEmailVerifiedResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/auth/dto/CheckEmailVerifiedResponseDto.java
@@ -1,0 +1,10 @@
+package com.todoay.api.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CheckEmailVerifiedResponseDto {
+    private boolean emailVerified;
+}

--- a/src/main/java/com/todoay/api/domain/auth/service/MailVerificationService.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/MailVerificationService.java
@@ -2,8 +2,11 @@ package com.todoay.api.domain.auth.service;
 
 import com.todoay.api.domain.auth.dto.AuthSendEmailRequestDto;
 import com.todoay.api.domain.auth.dto.AuthVerifyEmailTokenOnSingUpDto;
+import com.todoay.api.domain.auth.dto.CheckEmailVerifiedResponseDto;
 
 public interface MailVerificationService {
     String sendVerificationMail(AuthSendEmailRequestDto authSendEmailRequestDto);
     void verifyEmail(AuthVerifyEmailTokenOnSingUpDto authVerifyEmailTOkenOnSingUpDto);
+
+    CheckEmailVerifiedResponseDto checkEmailVerified(String email);
 }

--- a/src/main/java/com/todoay/api/domain/auth/service/MailVerificationServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/MailVerificationServiceImpl.java
@@ -2,6 +2,7 @@ package com.todoay.api.domain.auth.service;
 
 import com.todoay.api.domain.auth.dto.AuthSendEmailRequestDto;
 import com.todoay.api.domain.auth.dto.AuthVerifyEmailTokenOnSingUpDto;
+import com.todoay.api.domain.auth.dto.CheckEmailVerifiedResponseDto;
 import com.todoay.api.domain.auth.entity.Auth;
 import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.auth.utility.MailHandler;
@@ -51,5 +52,12 @@ public class MailVerificationServiceImpl implements MailVerificationService {
         String email = jwtTokenProvider.validateToken(authVerifyEmailTOkenOnSingUpDto.getEmailToken()).getSubject();
         Auth auth = authRepository.findByEmail(email).orElseThrow(EmailNotFoundException::new);
         auth.completeEmailVerification();
+    }
+
+    @Override
+    public CheckEmailVerifiedResponseDto checkEmailVerified(String email) {
+        Auth auth = authRepository.findByEmail(email).orElseThrow(EmailNotFoundException::new);
+        boolean emailVerified = auth.getEmailVerifiedAt() == null ? false : true;
+        return CheckEmailVerifiedResponseDto.builder().emailVerified(emailVerified).build();
     }
 }

--- a/src/test/java/com/todoay/api/domain/auth/service/MailVerificationServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/service/MailVerificationServiceImplTest.java
@@ -24,14 +24,17 @@ class MailVerificationServiceImplTest {
     @Autowired
     AuthRepository authRepository;
 
+    AuthSaveDto dto;
+    AuthSaveDto dto2;
+
     @BeforeEach
     void before_each() {
-        AuthSaveDto dto = new AuthSaveDto();
+        dto = new AuthSaveDto();
         dto.setEmail("test@naver.com");
         dto.setNickname("tester");
         dto.setPassword("12341234");
 
-        AuthSaveDto dto2 = new AuthSaveDto();
+        dto2 = new AuthSaveDto();
         dto2.setEmail("test2@naver.com");
         dto2.setNickname("tester2");
         dto2.setPassword("22222222");
@@ -44,7 +47,7 @@ class MailVerificationServiceImplTest {
     void verifyEmail() {
         // given
         // beforeEach
-        String email = "test@naver.com";
+        String email = dto.getEmail();
 
         // when
         String emailToken = mailVerificationService.sendVerificationMail(AuthSendEmailRequestDto.builder().email(email).build());
@@ -53,5 +56,18 @@ class MailVerificationServiceImplTest {
         // then
         Auth auth = authRepository.findByEmail(email).get();
         Assertions.assertNotNull(auth.getEmailVerifiedAt());
+    }
+
+    @Test
+    void checkEmailVerified() {
+        // given
+        // beforeEach
+        String email1 = dto.getEmail();
+
+        // when
+        boolean emailVerified1 = mailVerificationService.checkEmailVerified(email1).isEmailVerified();
+
+        // then
+        Assertions.assertEquals(emailVerified1, false);
     }
 }


### PR DESCRIPTION
### HTTP GET /auth/{email}/email-verified

#### 200
```json
{
  "emailVerified": true
}
```

#### 400 email에 해당하는 계정이 없는 경우
```json
{
  "timestamp": "2022-07-22T12:44:45.614Z",
  "status": 401,
  "error": "UNAUTHORIZED",
  "code": "JWT_EXPIRED",
  "message": "이메일 토큰이 만료되었습니다.",
  "path": "/auth/email-verification"
}
```