### PR TITLE
Issue#57 jwttokenprovider 이름 및 구조 변경

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -5,7 +5,7 @@ import com.todoay.api.domain.auth.service.AuthService;
 import com.todoay.api.domain.profile.service.ProfileService;
 import com.todoay.api.global.exception.ErrorResponse;
 import com.todoay.api.global.exception.ValidErrorResponse;
-import com.todoay.api.global.jwt.JwtTokenProvider;
+import com.todoay.api.global.jwt.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,7 +22,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final ProfileService profileService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signup(@RequestBody @Validated AuthSaveDto authSaveDto) {  // validated하고 설정하면 그 중에 몇개만 골라서 검사 해줌. valid는 다 함
@@ -36,8 +36,8 @@ public class AuthController {
     public ResponseEntity<LoginResponseDto> login(@RequestBody @Validated LoginRequestDto loginRequestDto) {
         authService.login(loginRequestDto);
 
-        String accessToken = jwtTokenProvider.createAccessToken(loginRequestDto.getEmail());
-        String refreshToken = jwtTokenProvider.createRefreshToken(loginRequestDto.getEmail());
+        String accessToken = jwtProvider.createAccessToken(loginRequestDto.getEmail());
+        String refreshToken = jwtProvider.createRefreshToken(loginRequestDto.getEmail());
         return ResponseEntity.status(201).body(new LoginResponseDto(accessToken,refreshToken));
     }
 
@@ -53,7 +53,7 @@ public class AuthController {
     @PatchMapping("/password")
     public ResponseEntity<Void> changePassword(@RequestBody @Validated AuthUpdatePasswordReqeustDto dto) {
 
-        String loginId = jwtTokenProvider.getLoginId(); // 로그인 못한 상태에서 비밀번호 변경할 때엔 어떤 header를 쓰는지 정해야 할듯??
+        String loginId = jwtProvider.getLoginId(); // 로그인 못한 상태에서 비밀번호 변경할 때엔 어떤 header를 쓰는지 정해야 할듯??
         authService.updateAuthPassword(loginId,dto);
 
         return ResponseEntity.noContent().build();
@@ -69,7 +69,7 @@ public class AuthController {
     )
     @DeleteMapping("/my")
     public ResponseEntity<Void> deleteAccount() {
-        String loginId = jwtTokenProvider.getLoginId();
+        String loginId = jwtProvider.getLoginId();
         authService.deleteAuth(loginId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -22,7 +22,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final ProfileService profileService;
-    private final JwtProvider jwtProvider;
+//    private final JwtProvider jwtProvider;
 
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signup(@RequestBody @Validated AuthSaveDto authSaveDto) {  // validated하고 설정하면 그 중에 몇개만 골라서 검사 해줌. valid는 다 함
@@ -34,11 +34,8 @@ public class AuthController {
     // login 할 때는 jwt로 반환하기로
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@RequestBody @Validated LoginRequestDto loginRequestDto) {
-        authService.login(loginRequestDto);
-
-        String accessToken = jwtProvider.createAccessToken(loginRequestDto.getEmail());
-        String refreshToken = jwtProvider.createRefreshToken(loginRequestDto.getEmail());
-        return ResponseEntity.status(201).body(new LoginResponseDto(accessToken,refreshToken));
+        LoginResponseDto tokens = authService.login(loginRequestDto);
+        return ResponseEntity.status(201).body(tokens);
     }
 
     @Operation(
@@ -53,8 +50,7 @@ public class AuthController {
     @PatchMapping("/password")
     public ResponseEntity<Void> changePassword(@RequestBody @Validated AuthUpdatePasswordReqeustDto dto) {
 
-        String loginId = jwtProvider.getLoginId(); // 로그인 못한 상태에서 비밀번호 변경할 때엔 어떤 header를 쓰는지 정해야 할듯??
-        authService.updateAuthPassword(loginId,dto);
+        authService.updateAuthPassword(dto);
 
         return ResponseEntity.noContent().build();
     }
@@ -69,8 +65,8 @@ public class AuthController {
     )
     @DeleteMapping("/my")
     public ResponseEntity<Void> deleteAccount() {
-        String loginId = jwtProvider.getLoginId();
-        authService.deleteAuth(loginId);
+
+        authService.deleteAuth();
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/todoay/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/AuthService.java
@@ -4,18 +4,19 @@ package com.todoay.api.domain.auth.service;
 import com.todoay.api.domain.auth.dto.AuthSaveDto;
 import com.todoay.api.domain.auth.dto.AuthUpdatePasswordReqeustDto;
 import com.todoay.api.domain.auth.dto.LoginRequestDto;
+import com.todoay.api.domain.auth.dto.LoginResponseDto;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 
 public interface AuthService extends UserDetailsService {
     // spring security 필수 메소드
 
-    void updateAuthPassword(String email, AuthUpdatePasswordReqeustDto dto); // 비밀번호 변경
+    void updateAuthPassword(AuthUpdatePasswordReqeustDto dto); // 비밀번호 변경
 
     // 계정 탈퇴
-    void deleteAuth(String email);
+    void deleteAuth();
     Long save(AuthSaveDto authSaveDto);
-    void login(LoginRequestDto loginRequestDto);
+    LoginResponseDto login(LoginRequestDto loginRequestDto);
 
     boolean isExistEmail(String email);
 }

--- a/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
@@ -78,7 +78,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public void login(LoginRequestDto loginRequestDto) {
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
         Auth auth = authRepository.findByEmail(loginRequestDto.getEmail())
                 .orElseThrow(LoginUnmatchedException::new);
 

--- a/src/main/java/com/todoay/api/domain/auth/service/MailVerificationServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/MailVerificationServiceImpl.java
@@ -7,7 +7,7 @@ import com.todoay.api.domain.auth.entity.Auth;
 import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.auth.utility.MailHandler;
 import com.todoay.api.domain.profile.exception.EmailNotFoundException;
-import com.todoay.api.global.jwt.JwtTokenProvider;
+import com.todoay.api.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -18,7 +18,7 @@ import javax.mail.MessagingException;
 @Service
 @RequiredArgsConstructor
 public class MailVerificationServiceImpl implements MailVerificationService {
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
     private final JavaMailSender mailSender;
     private final AuthRepository authRepository;
 
@@ -28,7 +28,7 @@ public class MailVerificationServiceImpl implements MailVerificationService {
             MailHandler mailHandler = new MailHandler(mailSender);
             mailHandler.setTo(authSendEmailRequestDto.getEmail());
             mailHandler.setSubject("[TODOAY] 이메일 인증을 완료해주세요.");
-            String emailToken = jwtTokenProvider.createEmailToken(authSendEmailRequestDto.getEmail());
+            String emailToken = jwtProvider.createEmailToken(authSendEmailRequestDto.getEmail());
             String sb = "<a href='" +
                     "http://" + "localhost:8080/auth/email-verification?emailToken=" + emailToken +
                     "')>링크를 클릭하여 인증을 완료해주세요</a>";
@@ -49,7 +49,7 @@ public class MailVerificationServiceImpl implements MailVerificationService {
 //         io.jsonwebtoken.SignatureException – if the claimsJws JWS signature validation fails
 //         io.jsonwebtoken.ExpiredJwtException – if the specified JWT is a Claims JWT and the Claims has an expiration time before the time this method is invoked.
 //         IllegalArgumentException – if the claimsJws string is null or empty or only whitespace
-        String email = jwtTokenProvider.validateToken(authVerifyEmailTOkenOnSingUpDto.getEmailToken()).getSubject();
+        String email = jwtProvider.validateToken(authVerifyEmailTOkenOnSingUpDto.getEmailToken()).getSubject();
         Auth auth = authRepository.findByEmail(email).orElseThrow(EmailNotFoundException::new);
         auth.completeEmailVerification();
     }

--- a/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
@@ -5,16 +5,14 @@ import com.todoay.api.domain.profile.dto.ProfileUpdateReqeustDto;
 import com.todoay.api.domain.profile.service.ProfileService;
 import com.todoay.api.global.exception.ErrorResponse;
 import com.todoay.api.global.exception.ValidErrorResponse;
-import com.todoay.api.global.jwt.JwtTokenProvider;
+import com.todoay.api.global.jwt.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -29,7 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 public class ProfileController {
 
     private final ProfileService profileService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
 
 
 
@@ -44,7 +42,7 @@ public class ProfileController {
     @GetMapping("/profile/my")
     public ResponseEntity<ProfileReadResponseDto> getMyProfile(HttpServletRequest request) {
 
-        String email = jwtTokenProvider.getLoginId();
+        String email = jwtProvider.getLoginId();
         ProfileReadResponseDto profile = profileService.readMyProfile(email);
 
         return ResponseEntity.ok(profile);
@@ -62,7 +60,7 @@ public class ProfileController {
     @PutMapping("/profile/my")
     public ResponseEntity updateProfile(HttpServletRequest request, @RequestBody @Validated ProfileUpdateReqeustDto dto) {
 
-        String email = jwtTokenProvider.getLoginId();
+        String email = jwtProvider.getLoginId();
         log.info("dto = {} ",dto);
         profileService.updateMyProfile(email, dto);
 

--- a/src/main/java/com/todoay/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/todoay/api/global/config/WebSecurityConfig.java
@@ -3,7 +3,7 @@ package com.todoay.api.global.config;
 import com.todoay.api.domain.auth.service.AuthService;
 import com.todoay.api.global.jwt.JwtAuthenticationFilter;
 import com.todoay.api.global.jwt.JwtExceptionHandlingFilter;
-import com.todoay.api.global.jwt.JwtTokenProvider;
+import com.todoay.api.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -14,15 +14,14 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import static org.hibernate.criterion.Restrictions.and;
-
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final AuthService authService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtTokenProvider;
+
 
 
     @Override
@@ -53,7 +52,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                         .invalidateHttpSession(true)
 
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,authService), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionHandlingFilter(), JwtAuthenticationFilter.class);
 
     }

--- a/src/main/java/com/todoay/api/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/todoay/api/global/jwt/JwtAuthenticationFilter.java
@@ -17,9 +17,9 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final Logger LOGGER = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtTokenProvider;
 
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 

--- a/src/main/java/com/todoay/api/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/todoay/api/global/jwt/JwtAuthenticationFilter.java
@@ -2,8 +2,11 @@ package com.todoay.api.global.jwt;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -17,9 +20,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final Logger LOGGER = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
     private final JwtProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
 
-    public JwtAuthenticationFilter(JwtProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtProvider jwtTokenProvider,UserDetailsService userDetailsService) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
     }
 
     @Override
@@ -29,12 +34,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         LOGGER.info("[doFilterInternal] token 값 유효성 체크 시작");
         if (token != null && jwtTokenProvider.validateToken(token) == null) {  // (2)
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            Authentication authentication = this.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);  // (3)
             LOGGER.info("[doFilterInternal] token 값 유효성 체크 완료");
         }
 
         filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    // 필터에서 인증이 성공했을 때 SecurityContextHolder에 저장할 Authentication을 생성하는 역할
+    // 이걸 구현하는 편한 방법은 UsernamePasswordAuthenticationToken을 사용하는 것
+    public Authentication getAuthentication(String token) {
+        LOGGER.info("[getAuthentication] 토큰 인증 정보 조회 시작");
+        UserDetails userDetails = userDetailsService.loadUserByUsername(jwtTokenProvider.getUserEmail(token));
+        LOGGER.info("[getAuthentication] 토큰 인증 정보 조회 완료, UserDetails UserName : {}", userDetails.getUsername());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }
 // (1) JwtTokenProvider를 통해 servletRequest에서 토큰 추출

--- a/src/main/java/com/todoay/api/global/jwt/JwtProvider.java
+++ b/src/main/java/com/todoay/api/global/jwt/JwtProvider.java
@@ -1,6 +1,9 @@
 package com.todoay.api.global.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,21 +21,20 @@ import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Objects;
 
 @PropertySource("classpath:secret.properties")
 @Component
 @RequiredArgsConstructor
-public class JwtTokenProvider {
+public class JwtProvider {
     @Value("${jwt.key}")
     private String secretKey;
     private final long EMAIL_TOKEN_EXPIRATION = 1000 * 60 * 5;
     private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24;
     private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 30;
 
-    private final Logger LOGGER = LoggerFactory.getLogger(JwtTokenProvider.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(JwtProvider.class);
     private final UserDetailsService userDetailsService;
 
     @PostConstruct // init() 메소드

--- a/src/main/java/com/todoay/api/global/jwt/JwtProvider.java
+++ b/src/main/java/com/todoay/api/global/jwt/JwtProvider.java
@@ -37,7 +37,6 @@ public class JwtProvider {
     private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 30;
 
     private final Logger LOGGER = LoggerFactory.getLogger(JwtProvider.class);
-    private final UserDetailsService userDetailsService;
 
     @PostConstruct // init() 메소드
     protected void init() {  // secretKey를 Base64형식으로 인코딩함. 인코딩 전후 확인 로깅
@@ -77,16 +76,6 @@ public class JwtProvider {
     public String createRefreshToken(String email) {
         // refreshToken 저장해줘야한다.
         return createToken(REFRESH_TOKEN_EXPIRATION, email);
-    }
-
-
-    // 필터에서 인증이 성공했을 때 SecurityContextHolder에 저장할 Authentication을 생성하는 역할
-    // 이걸 구현하는 편한 방법은 UsernamePasswordAuthenticationToken을 사용하는 것
-    public Authentication getAuthentication(String token) {
-        LOGGER.info("[getAuthentication] 토큰 인증 정보 조회 시작");
-        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserEmail(token));
-        LOGGER.info("[getAuthentication] 토큰 인증 정보 조회 완료, UserDetails UserName : {}", userDetails.getUsername());
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
     public String getUserEmail(String token) {

--- a/src/test/java/com/todoay/api/domain/auth/controller/MailVerificationControllerTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/controller/MailVerificationControllerTest.java
@@ -1,13 +1,11 @@
 package com.todoay.api.domain.auth.controller;
 
 import com.todoay.api.domain.auth.dto.AuthSaveDto;
-import com.todoay.api.domain.auth.dto.AuthSendEmailRequestDto;
 import com.todoay.api.domain.auth.dto.AuthVerifyEmailTokenOnSingUpDto;
 import com.todoay.api.domain.auth.entity.Auth;
 import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.auth.service.AuthService;
-import com.todoay.api.domain.auth.service.MailVerificationService;
-import com.todoay.api.global.jwt.JwtTokenProvider;
+import com.todoay.api.global.jwt.JwtProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +26,7 @@ class MailVerificationControllerTest {
     AuthRepository authRepository;
 
     @Autowired
-    JwtTokenProvider jwtTokenProvider;
+    JwtProvider jwtProvider;
 
     AuthSaveDto dto1;
     AuthSaveDto dto2;
@@ -54,7 +52,7 @@ class MailVerificationControllerTest {
         // given
         // beforeEach
         String email = dto1.getEmail();
-        String emailToken = jwtTokenProvider.createEmailToken(email);
+        String emailToken = jwtProvider.createEmailToken(email);
         // 테스트 하려면 만료된 토큰 생성하는 것이 필요할 듯. JwtTokenProvider::createToken을 public으로 바꾸면 가능.
 
         // when

--- a/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -55,7 +56,9 @@ class AuthServiceImplTest {
         String passwordBefore = auth.getPassword();
 
 
-        authService.updateAuthPassword(email, dto);
+        // token이 없어서 수정
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        auth.setPassword(encoder.encode(dto.getPassword()));
 
 
         Auth updated = em.createQuery("select a from Auth a where a.email =: email", Auth.class)


### PR DESCRIPTION
- JwtTokenProvider의 이름을 JwtProvider로 수정
- JwtTokenProvider가 UserDetailService를 의존하여 AuthService에서 이를 사용하지 못하기 때문에, 구조적 통일을 위해 JwtTokenProvider가 UserDetailService를 의존하지 않고, JwtAuthenticationFilter가 의존하도록 구조 변경
- UserDetailService를 의존하지 않게 됨으로 인해 AuthController, AuthService의 코드 수정