### PR TITLE
Issue#62 refresh token 관련 기능 추가, spring security 관련 기능 수정

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/controller/MailVerificationController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/MailVerificationController.java
@@ -68,7 +68,7 @@ public class MailVerificationController {
         return modelAndView;
     }
 
-    @GetMapping("/auth/{email}/email-verified")
+    @GetMapping("/{email}/email-verified")
     @Operation(
             summary = "path variable로 받은 email의 계정의 이메일 인증 여부를 응답한다.",
             description = "{'emailVerified': boolean}",

--- a/src/main/java/com/todoay/api/domain/auth/dto/RefreshRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/auth/dto/RefreshRequestDto.java
@@ -1,0 +1,12 @@
+package com.todoay.api.domain.auth.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class RefreshRequestDto {
+
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/todoay/api/domain/auth/dto/RefreshResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/auth/dto/RefreshResponseDto.java
@@ -1,0 +1,17 @@
+package com.todoay.api.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class RefreshResponseDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public RefreshResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/todoay/api/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/todoay/api/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,28 @@
+package com.todoay.api.domain.auth.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class RefreshToken {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @Column(nullable = false)
+    private String token;
+
+    @Column(nullable = false)
+    private String subjectEmail;
+
+    public RefreshToken(String token, String subjectEmail) {
+        this.token = token;
+        this.subjectEmail = subjectEmail;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.token = refreshToken;
+    }
+}

--- a/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
@@ -12,6 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
 
     EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
     LOGIN_FAILED(HttpStatus.NOT_FOUND, "로그인에 실패하였습니다."),
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "전달하신 RefreshToken은 존재하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/todoay/api/domain/auth/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,13 @@
+package com.todoay.api.domain.auth.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+import com.todoay.api.global.exception.ErrorCode;
+
+import static com.todoay.api.domain.auth.exception.AuthErrorCode.REFRESH_TOKEN_NOT_FOUND;
+
+public class RefreshTokenNotFoundException extends AbstractApiException {
+
+    public RefreshTokenNotFoundException() {
+        super(REFRESH_TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/todoay/api/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.todoay.api.domain.auth.repository;
+
+import com.todoay.api.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken,Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findBySubjectEmail(String email);
+
+    void deleteBySubjectEmail(String email);
+}

--- a/src/main/java/com/todoay/api/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,15 @@
+package com.todoay.api.domain.auth.service;
+
+import com.todoay.api.domain.auth.dto.LoginRequestDto;
+import com.todoay.api.domain.auth.dto.LoginResponseDto;
+import com.todoay.api.domain.auth.dto.RefreshRequestDto;
+import com.todoay.api.domain.auth.dto.RefreshResponseDto;
+
+public interface RefreshTokenService {
+    // login 할 때 저장해주기.
+    void login(LoginRequestDto dto, String refreshToken);
+    // refresh 될 때 access token과 refreshtoken 재발급 해주기. 재발급 하면 기존에 있던 것을 삭제하나 아니면 업데이트하나..?
+
+    RefreshResponseDto refreshTokens(RefreshRequestDto dto);
+
+}

--- a/src/main/java/com/todoay/api/domain/auth/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/RefreshTokenServiceImpl.java
@@ -1,0 +1,50 @@
+package com.todoay.api.domain.auth.service;
+
+import com.todoay.api.domain.auth.dto.LoginRequestDto;
+import com.todoay.api.domain.auth.dto.RefreshRequestDto;
+import com.todoay.api.domain.auth.dto.RefreshResponseDto;
+import com.todoay.api.domain.auth.entity.RefreshToken;
+import com.todoay.api.domain.auth.exception.RefreshTokenNotFoundException;
+import com.todoay.api.domain.auth.repository.RefreshTokenRepository;
+import com.todoay.api.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service @Transactional
+public class RefreshTokenServiceImpl implements RefreshTokenService{
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void login(LoginRequestDto dto, String refreshToken) {
+        String email = dto.getEmail();
+
+        refreshTokenRepository.findBySubjectEmail(email)
+                .ifPresent(refreshTokenRepository::delete);
+
+        refreshTokenRepository.save(new RefreshToken(refreshToken, email));
+    }
+
+    @Override
+    public RefreshResponseDto refreshTokens(RefreshRequestDto dto) {
+
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(dto.getRefreshToken())
+                .orElseThrow(RefreshTokenNotFoundException::new);
+
+        // refreshToken validation
+        jwtProvider.validateToken(refreshToken.getToken());
+        String accessToken = jwtProvider.createAccessToken(refreshToken.getSubjectEmail());
+
+        // refresh refreshToken expiration
+        String updatedRefreshToken = jwtProvider.createRefreshToken(refreshToken.getSubjectEmail());
+        refreshToken.updateRefreshToken(updatedRefreshToken);
+
+        return RefreshResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(updatedRefreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/todoay/api/global/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/todoay/api/global/config/GlobalExceptionHandler.java
@@ -53,4 +53,24 @@ public class GlobalExceptionHandler {
         return ErrorResponse.toResponseEntity(SQL_INTEGRITY_CONSTRAINT_VIOLATION, request.getRequestURI());
     }
 
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<?> handleExpiredJwtException(HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(GlobalErrorCode.JWT_EXPIRED, request.getRequestURI());
+    }
+
+    @ExceptionHandler(SignatureException.class)
+    public ResponseEntity<?> handleSignatureException(HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(GlobalErrorCode.JWT_NOT_VERIFIED, request.getRequestURI());
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    public ResponseEntity<?> handleMalformedJwtException(HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(GlobalErrorCode.JWT_MALFORMED, request.getRequestURI());
+    }
+
+    @ExceptionHandler(UnsupportedJwtException.class)
+    public ResponseEntity<?> handleUnsupportedJwtException(HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(GlobalErrorCode.JWT_UNSUPPORTED, request.getRequestURI());
+    }
+
 }

--- a/src/main/java/com/todoay/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/todoay/api/global/config/WebSecurityConfig.java
@@ -37,15 +37,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
                 .and()
                     .authorizeRequests()
-                        .antMatchers("/auth/**", "/signup", "/user/**", "/docs", "/profile/**", "/h2-console/**").permitAll()  // 누구나 접근 가능 // profile/my는 permitAll하면 안됨.
+                        .antMatchers("/auth/**", "/signup", "/docs", "/h2-console/**").permitAll()  // 누구나 접근 가능 // profile/my는 permitAll하면 안됨.
                         .antMatchers("/").hasRole("USER")  // USER, ADMIN만 접근 가능
                         .antMatchers("/admin").hasRole("ADMIN")  // ADMIN만
                         .anyRequest().authenticated()  // 나머지 요청들은 권한의 종류에 상관없이 권한이 있어야 접근
-
-                .and()
-                    .formLogin()
-                        .loginPage("/auth")  // 로그인 페이지 링크
-                        .defaultSuccessUrl("/")  // 로그인 성공 후 리다이렉트 주소
                 .and()
                     .logout()
                         .logoutSuccessUrl("/")  // 로그아웃 성공시 리다이렉트 주소

--- a/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode{
     ARGUMENT_FORMAT_INVALID(HttpStatus.BAD_REQUEST,"양식에 맞지 않은 입력값이 입력되었습니다."),
-    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "이메일 토큰이 만료되었습니다."), // v
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."), // v
     JWT_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "토큰의 시그내처가 유효하지 않습니다."), // v
     JWT_MALFORMED(HttpStatus.UNAUTHORIZED, "토큰의 형식이 잘못되었습니다. 토큰은 [header].[payload].[secret]의 형식이어야 합니다."), // v
     JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "지원하지 않는 종류의 토큰입니다."),

--- a/src/main/java/com/todoay/api/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/todoay/api/global/jwt/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         LOGGER.info("[doFilterInternal] token 값 추출 완료. token : {}", token);
 
         LOGGER.info("[doFilterInternal] token 값 유효성 체크 시작");
-        if (token != null && jwtTokenProvider.validateToken(token) == null) {  // (2)
+        if (token != null && jwtTokenProvider.validateToken(token) != null) {  // (2)
             Authentication authentication = this.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);  // (3)
             LOGGER.info("[doFilterInternal] token 값 유효성 체크 완료");

--- a/src/main/java/com/todoay/api/global/jwt/JwtProvider.java
+++ b/src/main/java/com/todoay/api/global/jwt/JwtProvider.java
@@ -1,7 +1,7 @@
 package com.todoay.api.global.jwt;
 
-import com.todoay.api.global.exception.*;
-import io.jsonwebtoken.*;
+import com.todoay.api.domain.auth.entity.Auth;
+import com.todoay.api.global.exception.JwtHeaderNotFoundException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -11,20 +11,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Objects;
 
 @PropertySource("classpath:secret.properties")
 @Component
@@ -74,7 +70,6 @@ public class JwtProvider {
     }
 
     public String createRefreshToken(String email) {
-        // refreshToken 저장해줘야한다.
         return createToken(REFRESH_TOKEN_EXPIRATION, email);
     }
 
@@ -97,9 +92,11 @@ public class JwtProvider {
     }
 
     public String getLoginId() {
-        HttpServletRequest httpServletRequest = Objects.requireNonNull(((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest());
-        String token = httpServletRequest.getHeader("X-AUTH-TOKEN");
-        return getUserEmail(token);
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication authentication = context.getAuthentication();
+        Auth auth = (Auth) authentication.getPrincipal();
+        LOGGER.info("auth = {}", auth);
+        return auth.getEmail();
     }
 
     public Claims validateToken(String token) {


### PR DESCRIPTION
### 1. 이메일 인증 여부 확인 URL mapping 수정
- from [GET] /auth/auth/{email}/email-verified
- to [GET] /auth/{email}/email-verified

### 2. RefreshToken 관련 기능 추가
- RefreshToken entity 생성
- RefreshToken repository 생성
- RefreshTokenService 생성
- login 로직 수정, refresh 로직 추가

**로직**
- [/auth/login] jwtProvider에 의해서 토큰이 생성된 이후 refreshtokenService는 email정보와 생성된 refreshtoken 정보를 받아 db에 저장한다. (이때 기존에 email에 해당하는 refreshToken이 존재한다면 삭제하고 다시 발급한다.)

- [/auth/refresh] body를 통해 refreshToken을 전달받는다. 전달받은 refreshToken에 대한 검사를 하고 새로운 토큰을 전달한다.

### 3. Security 관련 기능 수정

1. WebSecurity에 login 관련 부분 삭제 -> 403 error가 터지면 자동으로 login으로 설정된 url로 이동하여 403에러가 아닌 404에러가 나옴. 이 부분은 프런트에서 로그인 화면으로 이전시키는 방법으로 해야 할 듯
2. JwtAuthenticationFilter에 필터링 메서드 오타 수정.
[기존] jwtTokenProvider.validateToken(token) == null
[수정] jwtTokenProvider.validateToken(token) != null
받아온 토큰값이 null이 아닐때 validation을 하는데, validation의 결과가 null 이어야 SecurityContextHolder에 Authentication을 설정하는 식으로 설정되어서 수정함.

3. JwtProvider의 getLoginId부분 header에 있는 토큰 값을 분해해서 사용하는 로직에서 SecurityContextHolder에 저장된 Authentication을 활용해서 얻어오는 방식으로 수정. 그런데 Email만 가져올지 Auth를 통째로 가져올지에 대해서는 고민을 해 봐야 할 듯. 현재는 기존 방식인 email을 가져오도록 설정.