### PR TITLE
Issue#69 enhance login and refatoring

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -37,8 +37,6 @@ public class AuthController {
     public ResponseEntity<Void> signup(@RequestBody @Validated AuthSaveDto authSaveDto) {  // validated하고 설정하면 그 중에 몇개만 골라서 검사 해줌. valid는 다 함
 
 
-
-
         authService.save(authSaveDto);
         // save까지 authService interface에 구현?
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -30,7 +30,8 @@ public class AuthController {
             description = "이메일,패스워드,닉네임을 입력하여 회원가입 진행. 각 항목별로 양식을 지키지 않을 경우 오류 발생.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "성공"),
-                    @ApiResponse(responseCode = "400", description = "올바른 이메일/패스워드/닉네임 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class)))
+                    @ApiResponse(responseCode = "400", description = "올바른 이메일/패스워드/닉네임 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
+                    @ApiResponse(responseCode = "409", description = "입력한 이메일 혹은 닉네임이 이미 존재한다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @PostMapping("/sign-up")
@@ -49,6 +50,7 @@ public class AuthController {
             responses = {
                     @ApiResponse(responseCode = "201", description = "성공"),
                     @ApiResponse(responseCode = "400", description = "올바른 이메일,패스워드 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
+                    @ApiResponse(responseCode = "403",description = "로그인 할 수 없는 계정으로 로그인 시도", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "일치하는 회원정보가 없음.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )

--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -35,6 +35,10 @@ public class AuthController {
     )
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signup(@RequestBody @Validated AuthSaveDto authSaveDto) {  // validated하고 설정하면 그 중에 몇개만 골라서 검사 해줌. valid는 다 함
+
+
+
+
         authService.save(authSaveDto);
         // save까지 authService interface에 구현?
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
 
 
-    EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
+    EMAIL_DUPLICATE(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     LOGIN_FAILED(HttpStatus.NOT_FOUND, "로그인에 실패하였습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     LOGIN_DELETED_ACCOUNT(HttpStatus.FORBIDDEN,"삭제된 상태의 계정으로 로그인 시도했습니다."),

--- a/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
@@ -12,6 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
 
     EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
     LOGIN_FAILED(HttpStatus.NOT_FOUND, "로그인에 실패하였습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
+    LOGIN_DELETED_ACCOUNT(HttpStatus.FORBIDDEN,"삭제된 상태의 계정으로 로그인 시도했습니다."),
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "전달하신 RefreshToken은 존재하지 않습니다.")
     ;

--- a/src/main/java/com/todoay/api/domain/auth/exception/EmailNotVerifiedException.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/EmailNotVerifiedException.java
@@ -1,0 +1,11 @@
+package com.todoay.api.domain.auth.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+
+import static com.todoay.api.domain.auth.exception.AuthErrorCode.EMAIL_NOT_VERIFIED;
+
+public class EmailNotVerifiedException extends AbstractApiException {
+    public EmailNotVerifiedException() {
+        super(EMAIL_NOT_VERIFIED);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/auth/exception/LoginDeletedAccountException.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/LoginDeletedAccountException.java
@@ -1,0 +1,11 @@
+package com.todoay.api.domain.auth.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+
+import static com.todoay.api.domain.auth.exception.AuthErrorCode.LOGIN_DELETED_ACCOUNT;
+
+public class LoginDeletedAccountException extends AbstractApiException {
+    public LoginDeletedAccountException() {
+        super(LOGIN_DELETED_ACCOUNT);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/todoay/api/domain/auth/repository/AuthRepository.java
@@ -2,9 +2,14 @@ package com.todoay.api.domain.auth.repository;
 
 import com.todoay.api.domain.auth.entity.Auth;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface AuthRepository extends JpaRepository<Auth, Long> {
     Optional<Auth> findByEmail(String email);
+
+    @Query("select a from Auth a inner join a.profile p on p.nickname = :nickname")
+    Optional<Auth> findByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
@@ -50,21 +50,16 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public Long save(AuthSaveDto authSaveDto) {
 
-        // 이메일 중복검사
-
         authRepository.findByEmail(authSaveDto.getEmail())
                         .ifPresent(auth -> {
                             throw new EmailDuplicateException();
                         });
-
-        // 닉네임 중복검사..?
         authRepository.findByNickname(authSaveDto.getNickname())
                         .ifPresent(auth -> {
                             throw new NicknameDuplicateException();
                         });
 
         authSaveDto.setPassword(encoder.encode(authSaveDto.getPassword()));
-
         return authRepository.save(authSaveDto.toAuthEntity()).getId();
     }
 

--- a/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
@@ -6,9 +6,11 @@ import com.todoay.api.domain.auth.dto.AuthUpdatePasswordReqeustDto;
 import com.todoay.api.domain.auth.dto.LoginRequestDto;
 import com.todoay.api.domain.auth.dto.LoginResponseDto;
 import com.todoay.api.domain.auth.entity.Auth;
+import com.todoay.api.domain.auth.exception.EmailDuplicateException;
 import com.todoay.api.domain.auth.exception.LoginUnmatchedException;
 import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.profile.exception.EmailNotFoundException;
+import com.todoay.api.domain.profile.exception.NicknameDuplicateException;
 import com.todoay.api.global.exception.AbstractApiException;
 import com.todoay.api.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +47,19 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     public Long save(AuthSaveDto authSaveDto) {
+
+        // 이메일 중복검사
+
+        authRepository.findByEmail(authSaveDto.getEmail())
+                        .ifPresent(auth -> {
+                            throw new EmailDuplicateException();
+                        });
+
+        // 닉네임 중복검사..?
+        authRepository.findByNickname(authSaveDto.getNickname())
+                        .ifPresent(auth -> {
+                            throw new NicknameDuplicateException();
+                        });
 
         authSaveDto.setPassword(encoder.encode(authSaveDto.getPassword()));
 

--- a/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 public class ProfileController {
 
     private final ProfileService profileService;
-    private final JwtProvider jwtProvider;
 
 
 
@@ -40,10 +39,10 @@ public class ProfileController {
             }
     )
     @GetMapping("/profile/my")
-    public ResponseEntity<ProfileReadResponseDto> getMyProfile(HttpServletRequest request) {
+    public ResponseEntity<ProfileReadResponseDto> getMyProfile() {
 
-        String email = jwtProvider.getLoginId();
-        ProfileReadResponseDto profile = profileService.readMyProfile(email);
+
+        ProfileReadResponseDto profile = profileService.readMyProfile();
 
         return ResponseEntity.ok(profile);
     }
@@ -58,11 +57,9 @@ public class ProfileController {
             }
     )
     @PutMapping("/profile/my")
-    public ResponseEntity updateProfile(HttpServletRequest request, @RequestBody @Validated ProfileUpdateReqeustDto dto) {
-
-        String email = jwtProvider.getLoginId();
+    public ResponseEntity<Void> updateProfile(@RequestBody @Validated ProfileUpdateReqeustDto dto) {
         log.info("dto = {} ",dto);
-        profileService.updateMyProfile(email, dto);
+        profileService.updateMyProfile(dto);
 
         return ResponseEntity.status(204).build();
     }

--- a/src/main/java/com/todoay/api/domain/profile/exception/ProfileErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/profile/exception/ProfileErrorCode.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum ProfileErrorCode implements ErrorCode {
 
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 이메일입니다."),
-    NICKNAME_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다.");
+    NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
 
 
 

--- a/src/main/java/com/todoay/api/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/ProfileService.java
@@ -8,10 +8,10 @@ public interface ProfileService {
 
     // 내 정보 조회
 
-    ProfileReadResponseDto readMyProfile(String email); // jwt를 받고 jwt Service에서 받아야 할지, controller에서 jwtService를 받고 받아야 할지...
+    ProfileReadResponseDto readMyProfile(); // jwt를 받고 jwt Service에서 받아야 할지, controller에서 jwtService를 받고 받아야 할지...
 
     // 내 정보 변경
-    void updateMyProfile(String email, ProfileUpdateReqeustDto dto);
+    void updateMyProfile(ProfileUpdateReqeustDto dto);
 
     boolean nicknameExists(String nickname);
 

--- a/src/main/java/com/todoay/api/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/ProfileServiceImpl.java
@@ -6,6 +6,7 @@ import com.todoay.api.domain.profile.entity.Profile;
 import com.todoay.api.domain.profile.exception.EmailNotFoundException;
 import com.todoay.api.domain.profile.exception.NicknameDuplicateException;
 import com.todoay.api.domain.profile.repository.ProfileRepository;
+import com.todoay.api.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProfileServiceImpl implements ProfileService {
 
     private final ProfileRepository profileRepository;
+    private final JwtProvider jwtProvider;
 
 
     @Override
-    public ProfileReadResponseDto readMyProfile(String email) {
+    public ProfileReadResponseDto readMyProfile() {
 
+        String email = jwtProvider.getLoginId();
         Profile profile = getProfileByEmailOrElseThrowEmailNotFoundException(email);
 
         return ProfileReadResponseDto.createResponseDto(profile);
@@ -27,7 +30,8 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Transactional
     @Override
-    public void updateMyProfile(String email, ProfileUpdateReqeustDto dto) {
+    public void updateMyProfile(ProfileUpdateReqeustDto dto) {
+        String email = jwtProvider.getLoginId();
 
         String nickname = dto.getNickname();
         profileRepository.findProfileByNickname(nickname)

--- a/src/main/java/com/todoay/api/global/config/GlobalBeanConfig.java
+++ b/src/main/java/com/todoay/api/global/config/GlobalBeanConfig.java
@@ -1,0 +1,14 @@
+package com.todoay.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class GlobalBeanConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/todoay/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/todoay/api/global/config/WebSecurityConfig.java
@@ -22,6 +22,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private final AuthService authService;
     private final JwtProvider jwtTokenProvider;
 
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
 
 
     @Override
@@ -54,6 +56,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(authService).passwordEncoder(new BCryptPasswordEncoder());
+        auth.userDetailsService(authService).passwordEncoder(bCryptPasswordEncoder);
     }
 }

--- a/src/test/java/com/todoay/api/domain/auth/repository/AuthRepositoryTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/repository/AuthRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.todoay.api.domain.auth.repository;
+
+import com.todoay.api.domain.auth.dto.AuthSaveDto;
+import com.todoay.api.domain.auth.entity.Auth;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest @Transactional
+class AuthRepositoryTest {
+
+
+    @Autowired AuthRepository authRepository;
+
+    @BeforeEach
+    void before_each() {
+        AuthSaveDto dto = new AuthSaveDto();
+        dto.setEmail("test@naver.com");
+        dto.setNickname("tester");
+        dto.setPassword("12341234");
+
+        AuthSaveDto dto2 = new AuthSaveDto();
+        dto2.setEmail("test2@naver.com");
+        dto2.setNickname("tester2");
+        dto2.setPassword("22222222");
+
+        Auth auth1 = dto.toAuthEntity();
+
+        Auth auth2 = dto2.toAuthEntity();
+
+        authRepository.save(auth1);
+        authRepository.save(auth2);
+    }
+
+    @Test
+    void findByNickname() {
+
+        //when
+        String nickname = "tester";
+        Auth tester = authRepository.findByNickname(nickname).get();
+
+        //then
+
+        assertThat(tester.getEmail()).isEqualTo("test@naver.com");
+
+    }
+}

--- a/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
@@ -8,9 +8,6 @@ import com.todoay.api.domain.auth.exception.EmailDuplicateException;
 import com.todoay.api.domain.auth.exception.EmailNotVerifiedException;
 import com.todoay.api.domain.auth.exception.LoginDeletedAccountException;
 import com.todoay.api.domain.profile.exception.NicknameDuplicateException;
-import org.assertj.core.api.Assertions;
-import org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException;
-import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,14 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceException;
-
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
@@ -3,8 +3,12 @@ package com.todoay.api.domain.auth.service;
 import com.todoay.api.domain.auth.dto.AuthSaveDto;
 import com.todoay.api.domain.auth.dto.AuthUpdatePasswordReqeustDto;
 import com.todoay.api.domain.auth.entity.Auth;
+import com.todoay.api.domain.auth.exception.EmailDuplicateException;
+import com.todoay.api.domain.profile.exception.NicknameDuplicateException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +20,7 @@ import javax.persistence.PersistenceContext;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -51,6 +56,51 @@ class AuthServiceImplTest {
         for (Auth auth : auths) {
             em.remove(auth);
         }
+    }
+
+
+    @Test @DisplayName("회원가입 테스트")
+    void signUp() {
+        //given
+        AuthSaveDto dto = new AuthSaveDto();
+        dto.setEmail("test3@naver.com");
+        dto.setNickname("tester3");
+        dto.setPassword("22222222");
+
+        authService.save(dto);
+
+        //when
+        Auth findAuth = em.createQuery("select a from Auth a where a.email = :email", Auth.class)
+                .setParameter("email", dto.getEmail())
+                .getSingleResult();
+        // then
+        assertThat(findAuth.getEmail()).isEqualTo(dto.getEmail());
+    }
+
+    @Test @DisplayName("회원가입_예외_이메일_중복검사_실패")
+    void signUpEmailDuplicateException() {
+        //given
+        AuthSaveDto dto = new AuthSaveDto();
+        dto.setEmail("test@naver.com");
+        dto.setNickname("tester");
+        dto.setPassword("12341234");
+        //when
+        assertThatThrownBy(() -> authService.save(dto))
+                // then
+                .isInstanceOf(EmailDuplicateException.class);
+    }
+
+    @Test @DisplayName("회원가입_예외_닉네임_중복검사_실패")
+    void signUpNicknameDuplicateException() {
+        //given
+        AuthSaveDto dto = new AuthSaveDto();
+        dto.setEmail("test123@naver.com");
+        dto.setNickname("tester");
+        dto.setPassword("12341234");
+        //when
+        assertThatThrownBy(() -> authService.save(dto))
+                // then
+                .isInstanceOf(NicknameDuplicateException.class);
     }
 
 

--- a/src/test/java/com/todoay/api/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/profile/service/ProfileServiceImplTest.java
@@ -53,7 +53,7 @@ class ProfileServiceImplTest {
     void readMyProfile_Exception_EmailNotFoundException() {
 
 
-        assertThatThrownBy(() -> profileService.readMyProfile("tttttt"))
+        assertThatThrownBy(() -> profileService.readMyProfile())
                 .isInstanceOf(EmailNotFoundException.class);
     }
 
@@ -67,9 +67,9 @@ class ProfileServiceImplTest {
         dto.setImageUrl("c/user/example/picture/image1.png");
         String email = "test@naver.com";
 
-        profileService.updateMyProfile(email,dto);
+        profileService.updateMyProfile(dto);
 
-        ProfileReadResponseDto profile = profileService.readMyProfile(email);
+        ProfileReadResponseDto profile = profileService.readMyProfile();
         System.out.println(profile);
 
         assertThat(profile.getIntroMsg()).isEqualTo(introMsg);
@@ -82,7 +82,7 @@ class ProfileServiceImplTest {
         ProfileUpdateReqeustDto dto = new ProfileUpdateReqeustDto();
         dto.setNickname("tester");
 
-        assertThatThrownBy(() -> profileService.updateMyProfile("test@naver.com",dto))
+        assertThatThrownBy(() -> profileService.updateMyProfile(dto))
                 .isInstanceOf(NicknameDuplicateException.class);
 
 


### PR DESCRIPTION
### 1. Profile, Auth, BCryptPasswordEncoder 관련 리팩터링
**Profile**

- ProfileController에 jwtProvider 의존 삭제, 파라미터에 있는 HttpRequest 삭제
- ProfileService에서 사용하지 않는 파라미터 삭제
- ProfileServiceImpl에서 jwtProvider 의존

**Auth**
- AuthServiceImpl getAuthOrElseThrow 메서드 생성하여 중복코드 처리

**BCryptPasswordEncoder**
- GlobalBeanConfig 생성하여 bean 관리
- BCryptPasswordEncoder bean으로 등록하여 사용할 때마다 new 하는 방식에서 의존성 주입을 통해 사용하도록 수정

### 2. 회원가입 로직에 이메일, 닉네임 중복체크 기능 추가

- AuthServiceImpl.save에서 AuthRepository를 통해 email, nickname으로 검색했을 때, 결과가 존재하면 EmailDuplicateException, NicknameDuplicateException 발생. 각 Exception들은 409 code를 반환
- 관련 테스트 추가 및 이전 커밋으로 인해 변경된 메서드 관련 테스트 구조 변경

### 3. 로그인 로직에 이메일 검증 상태, 삭제 상태 확인 로직 추가
- 이메일이 검증되지 않은 경우에 로그인하는 경우엔 EmailNotVerifiedException(403)을 반환한다
- 삭제 상태의 계정을 통해 로그인 하는 경우엔 LoginDeletedAccountException(403)을 반환한다
- **삭제 상태 로그인은 삭제 로직이 추가될 경우엔 변할 수 도 있을 거 같다.**