### PR TITLE
issue#70 삭제 로직 추가

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/entity/Auth.java
+++ b/src/main/java/com/todoay/api/domain/auth/entity/Auth.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -62,6 +63,8 @@ public class Auth implements UserDetails {
 
     public void deleteAuth() {
         this.deletedAt = LocalDateTime.now();
+        email = UUID.randomUUID().toString();
+        profile.delete();
     }
 
     @Override // 계정이 가지고 있는 권한 목록 리턴

--- a/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
@@ -73,8 +73,6 @@ public class AuthServiceImpl implements AuthService {
         Auth auth = authRepository.findByEmail(email)
                 .orElseThrow(EmailNotFoundException::new);
         auth.deleteAuth();
-
-
     }
 
     @Override

--- a/src/main/java/com/todoay/api/domain/profile/entity/Profile.java
+++ b/src/main/java/com/todoay/api/domain/profile/entity/Profile.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -41,6 +42,12 @@ public class Profile {
         this.nickname = dto.getNickname();
         this.imgUrl = dto.getImageUrl();
         this.introMsg = dto.getIntroMsg();
+    }
+
+    public void delete() {
+        this.nickname = UUID.randomUUID().toString();
+        this.imgUrl = "";
+        this.introMsg = "";
     }
 
 


### PR DESCRIPTION
- auth의 email, profile의 nickname을 무작위 uuid로 배정.
- uuid의 경우 같은 값이 나올 확률이 극도로 적기 때문에, 겹쳤을 경우에 예외 처리는 따로 안했음.
- profile의 imageurl, 상태 메세지는 blank값으로 처리해놧는데, 프사의 경우 기본값이 생성이 되면 그것으로 저장하도록 수정하겠음.

issue#70