### PR TITLE
#80 프로필 수정에 있어서 기존과 같은 닉네임을 입력했을 경우 예외 처리 로직 변경

### DIFF
--- a/src/main/java/com/todoay/api/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/ProfileServiceImpl.java
@@ -32,15 +32,15 @@ public class ProfileServiceImpl implements ProfileService {
     @Override
     public void updateMyProfile(ProfileUpdateReqeustDto dto) {
         String email = jwtProvider.getLoginId();
+        Profile profile = getProfileByEmailOrElseThrowEmailNotFoundException(email);
 
         String nickname = dto.getNickname();
-        profileRepository.findProfileByNickname(nickname)
-                .ifPresent(p -> {
-                    throw new NicknameDuplicateException();
-                }
-        );
-
-        Profile profile = getProfileByEmailOrElseThrowEmailNotFoundException(email);
+        if(!profile.getNickname().equals(nickname))
+            profileRepository.findProfileByNickname(nickname)
+                    .ifPresent(p -> {
+                        throw new NicknameDuplicateException();
+                    }
+            );
         profile.updateProfile(dto);
     }
 


### PR DESCRIPTION
`  String email = jwtProvider.getLoginId();
        Profile profile = getProfileByEmailOrElseThrowEmailNotFoundException(email);

        String nickname = dto.getNickname();
        if(!profile.getNickname().equals(nickname))
            profileRepository.findProfileByNickname(nickname)
                    .ifPresent(p -> {
                        throw new NicknameDuplicateException();
                    }
            );
        profile.updateProfile(dto);`

조건절 추가하여 body로 전달받은 닉네임과 로그인 되어있는 계정의 닉네임이 동일하면 중복 검사를 실행하지 않도록 변경
#80