### PR TITLE
#85 비밀번호 변경 인증 로직 추가

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/dto/AuthUpdatePasswordReqeustDto.java
+++ b/src/main/java/com/todoay/api/domain/auth/dto/AuthUpdatePasswordReqeustDto.java
@@ -11,5 +11,8 @@ public class AuthUpdatePasswordReqeustDto {
 
     @NotNull
     @Pattern(regexp = "^(?=.*\\d)(?=.*[~`!@#$%\\^&()-])(?=.*[a-zA-Z]).{8,20}$", message = "비밀번호는 영문, 숫자, 특수문자로 이루어진 8~20자로 입력해야합니다.")
-    private String password;
+    private String originPassword;
+    @NotNull
+    @Pattern(regexp = "^(?=.*\\d)(?=.*[~`!@#$%\\^&()-])(?=.*[a-zA-Z]).{8,20}$", message = "비밀번호는 영문, 숫자, 특수문자로 이루어진 8~20자로 입력해야합니다.")
+    private String modifiedPassword;
 }

--- a/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
@@ -14,6 +14,7 @@ public enum AuthErrorCode implements ErrorCode {
     LOGIN_FAILED(HttpStatus.NOT_FOUND, "로그인에 실패하였습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     LOGIN_DELETED_ACCOUNT(HttpStatus.FORBIDDEN,"삭제된 상태의 계정으로 로그인 시도했습니다."),
+    PASSWORD_NOT_MATCHED(HttpStatus.UNAUTHORIZED,"올바르지 않은 비밀번호를 입력하였습니다."),
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "전달하신 RefreshToken은 존재하지 않습니다.")
     ;

--- a/src/main/java/com/todoay/api/domain/auth/exception/PasswordNotMatchedException.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/PasswordNotMatchedException.java
@@ -1,0 +1,12 @@
+package com.todoay.api.domain.auth.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+import com.todoay.api.global.exception.ErrorCode;
+
+import static com.todoay.api.domain.auth.exception.AuthErrorCode.PASSWORD_NOT_MATCHED;
+
+public class PasswordNotMatchedException extends AbstractApiException {
+    public PasswordNotMatchedException() {
+        super(PASSWORD_NOT_MATCHED);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/auth/service/AuthServiceImpl.java
@@ -6,10 +6,7 @@ import com.todoay.api.domain.auth.dto.AuthUpdatePasswordReqeustDto;
 import com.todoay.api.domain.auth.dto.LoginRequestDto;
 import com.todoay.api.domain.auth.dto.LoginResponseDto;
 import com.todoay.api.domain.auth.entity.Auth;
-import com.todoay.api.domain.auth.exception.EmailDuplicateException;
-import com.todoay.api.domain.auth.exception.EmailNotVerifiedException;
-import com.todoay.api.domain.auth.exception.LoginDeletedAccountException;
-import com.todoay.api.domain.auth.exception.LoginUnmatchedException;
+import com.todoay.api.domain.auth.exception.*;
 import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.profile.exception.EmailNotFoundException;
 import com.todoay.api.domain.profile.exception.NicknameDuplicateException;
@@ -71,9 +68,14 @@ public class AuthServiceImpl implements AuthService {
         String email = jwtProvider.getLoginId();
         Auth auth = getAuthOrElseThrow(email, new EmailNotFoundException());
 
-        String password = dto.getPassword();
+        log.info("originpwd = {}", dto.getOriginPassword());
+        log.info("modifiedPassword = {}", dto.getModifiedPassword());
 
-        String encodedPassword = encoder.encode(password);
+        if (!encoder.matches(dto.getOriginPassword(),auth.getPassword())) {
+            throw new PasswordNotMatchedException();
+        }
+        String modifiedPassword = dto.getModifiedPassword();
+        String encodedPassword = encoder.encode(modifiedPassword);
 
         auth.updatePassword(encodedPassword);
         log.info("updated password = {}", auth.getPassword());

--- a/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/auth/service/AuthServiceImplTest.java
@@ -143,7 +143,7 @@ class AuthServiceImplTest {
     @Test
     void updateAuthPassword() {
         AuthUpdatePasswordReqeustDto dto = new AuthUpdatePasswordReqeustDto();
-        dto.setPassword("password1234");
+        dto.setOriginPassword("password1234");
 
 
         String email = "test@naver.com";
@@ -157,7 +157,7 @@ class AuthServiceImplTest {
 
         // token이 없어서 수정
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        auth.setPassword(encoder.encode(dto.getPassword()));
+        auth.setPassword(encoder.encode(dto.getOriginPassword()));
 
 
         Auth updated = em.createQuery("select a from Auth a where a.email =: email", Auth.class)


### PR DESCRIPTION
- 현재 비밀번호도 같이 입력하여 인증 절차를 한번 더 거치는 로직을 추가하였다.

`  if (!encoder.matches(dto.getOriginPassword(),auth.getPassword())) {
            throw new PasswordNotMatchedException();
        }`

#85