### PR TITLE
Request 조작 시 발생할 수 있는 예외들에 대해서 Status Code변경

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
             responses = {
                     @ApiResponse(responseCode = "201", description = "성공"),
                     @ApiResponse(responseCode = "400", description = "올바른 이메일/패스워드/닉네임 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
-                    @ApiResponse(responseCode = "409", description = "입력한 이메일 혹은 닉네임이 이미 존재한다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "403", description = "허용되지 않은 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @PostMapping("/sign-up")

--- a/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/todoay/api/domain/auth/controller/AuthController.java
@@ -67,7 +67,8 @@ public class AuthController {
             responses = {
                     @ApiResponse(responseCode = "204", description = "성공"),
                     @ApiResponse(responseCode = "400", description = "올바른 비밀번호 양식을 입력하지 않음",content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))) ,
-                    @ApiResponse(responseCode = "401", description = "JWT 토큰 에러 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Origin password가 저장된 값과 일치하지 않을 때 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
@@ -84,7 +85,8 @@ public class AuthController {
             description = "토큰을 통해 얻은 email에 해당하는 계정의 상태를 삭제함으로 변경한다. 토큰에 관련되어 문제가 생길 경우 오류를 발생한다.",
             responses = {
                     @ApiResponse(responseCode = "204", description = "성공"),
-                    @ApiResponse(responseCode = "401", description = "JWT 토큰 에러" ,content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @DeleteMapping("/my")
@@ -131,7 +133,7 @@ public class AuthController {
             responses = {
                     @ApiResponse(responseCode = "201", description = "새로운 토큰을 발급한다.", content = @Content(schema = @Schema(implementation = RefreshResponseDto.class))),
                     @ApiResponse(responseCode = "400", description = "RefreshToken이 만료됨", content = @Content(schema = @Schema(implementation = ErrorResponse.class)) ),
-                    @ApiResponse(responseCode = "401", description = "JWT 관련 에러",content = @Content(schema = @Schema(implementation = ErrorResponse.class)) ),
+                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "전달받은 refreshToken이 존재하지 않음.",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
 

--- a/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
 
 
-    EMAIL_DUPLICATE(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    EMAIL_DUPLICATE(HttpStatus.FORBIDDEN, "이미 사용 중인 이메일입니다."),
     LOGIN_FAILED(HttpStatus.NOT_FOUND, "로그인에 실패하였습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     LOGIN_DELETED_ACCOUNT(HttpStatus.FORBIDDEN,"삭제된 상태의 계정으로 로그인 시도했습니다."),

--- a/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
@@ -35,7 +35,8 @@ public class ProfileController {
             description = "Jwt 토큰을 통해 얻은 email로 정보를 검색하여, 반환한다.",
             responses = {
                     @ApiResponse(responseCode = "200",description = "성공", content = @Content(schema = @Schema(implementation = ProfileReadResponseDto.class))),
-                    @ApiResponse(responseCode = "401", description = "JWT 토큰 에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/profile/my")
@@ -53,7 +54,8 @@ public class ProfileController {
             responses = {
                     @ApiResponse(responseCode = "204", description = "성공"),
                     @ApiResponse(responseCode = "400", description = "입력 값이 유효성 검사를 통과하지 못했습니다.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "JWT 토큰 에러", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @PutMapping("/profile/my")

--- a/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
@@ -35,8 +35,7 @@ public class ProfileController {
             description = "Jwt 토큰을 통해 얻은 email로 정보를 검색하여, 반환한다.",
             responses = {
                     @ApiResponse(responseCode = "200",description = "성공", content = @Content(schema = @Schema(implementation = ProfileReadResponseDto.class))),
-                    @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping("/profile/my")

--- a/src/main/java/com/todoay/api/domain/profile/exception/ProfileErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/profile/exception/ProfileErrorCode.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum ProfileErrorCode implements ErrorCode {
 
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 이메일입니다."),
-    NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+    NICKNAME_DUPLICATE(HttpStatus.FORBIDDEN, "이미 사용 중인 닉네임입니다.");
 
 
 

--- a/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorCode implements ErrorCode{
     ARGUMENT_FORMAT_INVALID(HttpStatus.BAD_REQUEST,"양식에 맞지 않은 입력값이 입력되었습니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."), // v
-    JWT_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "토큰의 시그내처가 유효하지 않습니다."), // v
-    JWT_MALFORMED(HttpStatus.UNAUTHORIZED, "토큰의 형식이 잘못되었습니다. 토큰은 [header].[payload].[secret]의 형식이어야 합니다."), // v
-    JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "지원하지 않는 종류의 토큰입니다."),
-    JWT_HEADER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT을 담은 Request Header가 존재하지 않습니다."), // v
+    JWT_NOT_VERIFIED(HttpStatus.FORBIDDEN, "토큰의 시그내처가 유효하지 않습니다."), // v
+    JWT_MALFORMED(HttpStatus.FORBIDDEN, "토큰의 형식이 잘못되었습니다. 토큰은 [header].[payload].[secret]의 형식이어야 합니다."), // v
+    JWT_UNSUPPORTED(HttpStatus.FORBIDDEN, "지원하지 않는 종류의 토큰입니다."),
+    JWT_HEADER_NOT_FOUND(HttpStatus.FORBIDDEN, "JWT을 담은 Request Header가 존재하지 않습니다."), // v
 
-    SQL_INTEGRITY_CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST,"DB 제약조건을 위반하였습니다.")
+    SQL_INTEGRITY_CONSTRAINT_VIOLATION(HttpStatus.FORBIDDEN,"DB 제약조건을 위반하였습니다.")
 
 
     ;


### PR DESCRIPTION
Request가 조작되어서 발생할 수 있는 예외들에 대해서 Status code를 403으로 변경하였다.

해당 예외들은 다음과 같다.

- JWT_NOT_VERIFIED - 일반적이지 않은 JWT를 헤더에 입력한 경우
- JWT_MALFORMED - 일반적이지 않은 JWT를 헤더에 입력한 경우
- JWT_UNSUPPORTED - 일반적이지 않은 JWT를 헤더에 입력한 경우
- JWT_HEADER_NOT_FOUND -  토큰을 담을 헤더가 존재하지 않은 Request인 경우
- SQL_INTEGRITY_CONSTRAINT_VIOLATION - 프런트에서 검증을 마쳤는데도 DB제약조건을 지키지 않고 저장되려는 경우
- EMAIL_DUPLICATE - 프런트에서 검증을 했는데 사용 중인 이메일로 회원가입 하려는 경우
- NICKNAME_DUPLICATE - 프런트에서 검증을 했는데 사용 중인 닉네임으로 회원가입 혹은 닉네임 변경 하려는 경우