### PR TITLE
해시태그 검색 기능, TODO에 해시태그 부착 기능 추가.

### DIFF
--- a/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
@@ -34,7 +34,7 @@ public class HashtagController {
 
     )
     @GetMapping("/auto")
-    public ResponseEntity<HashtagAutoCompleteResponseDto> searchHashtagAutoComplete(@RequestParam("name") String name) {
+    public ResponseEntity<HashtagAutoCompleteResponseDto> searchHashtagAutoComplete(@RequestParam("name")  String name) {
         HashtagAutoCompleteResponseDto dto = hashtagService.searchHashtagAutoComplete(name);
         return ResponseEntity.ok(dto);
     }
@@ -48,7 +48,7 @@ public class HashtagController {
             }
     )
     @GetMapping
-    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum") int pageNum) {
+    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum")  int pageNum) {
         HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, pageNum);
         return ResponseEntity.ok(dto);
     }

--- a/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
@@ -10,11 +10,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/hashtag")
@@ -34,7 +40,7 @@ public class HashtagController {
 
     )
     @GetMapping("/auto")
-    public ResponseEntity<HashtagAutoCompleteResponseDto> searchHashtagAutoComplete(@RequestParam("name")  String name) {
+    public ResponseEntity<HashtagAutoCompleteResponseDto> searchHashtagAutoComplete(@RequestParam("name") @NotBlank String name) {
         HashtagAutoCompleteResponseDto dto = hashtagService.searchHashtagAutoComplete(name);
         return ResponseEntity.ok(dto);
     }
@@ -48,7 +54,7 @@ public class HashtagController {
             }
     )
     @GetMapping
-    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum")  int pageNum) {
+    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") @NotBlank String name, @RequestParam("pageNum") @Min(0) int pageNum) {
         HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, pageNum);
         return ResponseEntity.ok(dto);
     }

--- a/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
@@ -3,6 +3,11 @@ package com.todoay.api.domain.hashtag.controller;
 import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
 import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
 import com.todoay.api.domain.hashtag.service.HashtagService;
+import com.todoay.api.global.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,12 +23,30 @@ public class HashtagController {
     private final HashtagService hashtagService;
 
 
+    @Operation(
+            summary = "해시태그 자동검색 기능",
+            description = "유저가 해시태그를 검색할 때, 자동으로 리스트 형태로 보여주는 기능",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공",  content = @Content(schema = @Schema(implementation = HashtagAutoCompleteResponseDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "허용되지 않은 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+
+    )
     @GetMapping("/auto")
     public ResponseEntity<HashtagAutoCompleteResponseDto> searchHashtagAutoComplete(@RequestParam("name") String name) {
         HashtagAutoCompleteResponseDto dto = hashtagService.searchHashtagAutoComplete(name);
         return ResponseEntity.ok(dto);
     }
-
+    @Operation(
+            summary = "해시태그 검색 기능",
+            description = "유저가 해시태그를 검색하면 리스트로 보여준다. 다음 페이지가 존재하면 다음 페이지를 검색한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공",  content = @Content(schema = @Schema(implementation = HashtagSearchResopnseDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "허용되지 않은 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @GetMapping
     public ResponseEntity<HashtagSearchResopnseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum") int pageNum) {
         HashtagSearchResopnseDto dto = hashtagService.searchHashtag(name, pageNum);

--- a/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
@@ -1,7 +1,7 @@
 package com.todoay.api.domain.hashtag.controller;
 
 import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
-import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResponseDto;
 import com.todoay.api.domain.hashtag.service.HashtagService;
 import com.todoay.api.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,14 +42,14 @@ public class HashtagController {
             summary = "해시태그 검색 기능",
             description = "유저가 해시태그를 검색하면 리스트로 보여준다. 다음 페이지가 존재하면 다음 페이지를 검색한다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공",  content = @Content(schema = @Schema(implementation = HashtagSearchResopnseDto.class))),
+                    @ApiResponse(responseCode = "200", description = "성공",  content = @Content(schema = @Schema(implementation = HashtagSearchResponseDto.class))),
                     @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "403", description = "허용되지 않은 접근", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping
-    public ResponseEntity<HashtagSearchResopnseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum") int pageNum) {
-        HashtagSearchResopnseDto dto = hashtagService.searchHashtag(name, pageNum);
+    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum") int pageNum) {
+        HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, pageNum);
         return ResponseEntity.ok(dto);
     }
 

--- a/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
@@ -1,12 +1,33 @@
 package com.todoay.api.domain.hashtag.controller;
 
+import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
 import com.todoay.api.domain.hashtag.service.HashtagService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/hashtag")
 public class HashtagController {
 
     private final HashtagService hashtagService;
+
+
+    @GetMapping("/auto")
+    public ResponseEntity<HashtagAutoCompleteResponseDto> searchHashtagAutoComplete(@RequestParam("name") String name) {
+        HashtagAutoCompleteResponseDto dto = hashtagService.searchHashtagAutoComplete(name);
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping
+    public ResponseEntity<HashtagSearchResopnseDto> searchHashtag(@RequestParam("name") String name, @RequestParam("pageNum") int pageNum) {
+        HashtagSearchResopnseDto dto = hashtagService.searchHashtag(name, pageNum);
+        return ResponseEntity.ok(dto);
+    }
+
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagAutoCompleteResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagAutoCompleteResponseDto.java
@@ -1,0 +1,15 @@
+package com.todoay.api.domain.hashtag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data @NoArgsConstructor @AllArgsConstructor
+public class HashtagAutoCompleteResponseDto {
+
+    private List<HashtagInfoDto> infos;
+
+
+}

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagInfoDto.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagInfoDto.java
@@ -8,13 +8,12 @@ import lombok.NoArgsConstructor;
 @Data @NoArgsConstructor @AllArgsConstructor
 public class HashtagInfoDto {
 
-    private Long id;
+
     private String name;
 
 
 
     public HashtagInfoDto(Hashtag hashtag) {
-        id = hashtag.getId();
         name = hashtag.getName();
     }
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagInfoDto.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagInfoDto.java
@@ -1,0 +1,20 @@
+package com.todoay.api.domain.hashtag.dto;
+
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data @NoArgsConstructor @AllArgsConstructor
+public class HashtagInfoDto {
+
+    private Long id;
+    private String name;
+
+
+
+    public HashtagInfoDto(Hashtag hashtag) {
+        id = hashtag.getId();
+        name = hashtag.getName();
+    }
+}

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagSearchResopnseDto.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagSearchResopnseDto.java
@@ -10,6 +10,6 @@ public class HashtagSearchResopnseDto {
 
 
     private boolean hasNext;
-    private int nextPage;
+    private int nextPageNum;
     private List<HashtagInfoDto> infos;
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagSearchResopnseDto.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagSearchResopnseDto.java
@@ -1,0 +1,15 @@
+package com.todoay.api.domain.hashtag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data @AllArgsConstructor
+public class HashtagSearchResopnseDto {
+
+
+    private boolean hasNext;
+    private int nextPage;
+    private List<HashtagInfoDto> infos;
+}

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagSearchResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/HashtagSearchResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data @AllArgsConstructor
-public class HashtagSearchResopnseDto {
+public class HashtagSearchResponseDto {
 
 
     private boolean hasNext;

--- a/src/main/java/com/todoay/api/domain/hashtag/dto/Sample.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/dto/Sample.java
@@ -1,4 +1,0 @@
-package com.todoay.api.domain.hashtag.dto;
-
-public class Sample {
-}

--- a/src/main/java/com/todoay/api/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/entity/Hashtag.java
@@ -1,12 +1,19 @@
 package com.todoay.api.domain.hashtag.entity;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
-@Entity
+@Entity @Getter @NoArgsConstructor
 public class Hashtag {
 
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     @Column(nullable = false, unique = true)
     private String name;
+
+    public Hashtag(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/exception/HashtagErrorcode.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/exception/HashtagErrorcode.java
@@ -1,4 +1,16 @@
 package com.todoay.api.domain.hashtag.exception;
 
-public enum HashtagErrorcode {
+import com.todoay.api.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor @Getter
+public enum HashtagErrorcode implements ErrorCode {
+
+    NO_MORE_DATA(HttpStatus.FORBIDDEN, "더 이상 검색할 수 있는 데이터가 존재하지 않습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String detailMessage;
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/exception/NoMoreDataException.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/exception/NoMoreDataException.java
@@ -1,0 +1,11 @@
+package com.todoay.api.domain.hashtag.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+
+import static com.todoay.api.domain.hashtag.exception.HashtagErrorcode.NO_MORE_DATA;
+
+public class NoMoreDataException extends AbstractApiException {
+    public NoMoreDataException() {
+        super(NO_MORE_DATA);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/repository/HashtagRepository.java
@@ -1,7 +1,19 @@
 package com.todoay.api.domain.hashtag.repository;
 
 import com.todoay.api.domain.hashtag.entity.Hashtag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HashtagRepository extends JpaRepository<Hashtag,Long> {
+
+
+    // 미리보기 5개 검색하기
+
+    List<Hashtag> findTop5ByNameStartsWith(String name);
+
+    // 페이지로 검색하기
+    Slice<Hashtag> findHashtagByNameStartsWith(String name, Pageable pageable);
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/repository/HashtagRepository.java
@@ -6,12 +6,14 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag,Long> {
 
+    Optional<Hashtag> findByName(String name);
+
 
     // 미리보기 5개 검색하기
-
     List<Hashtag> findTop5ByNameStartsWith(String name);
 
     // 페이지로 검색하기

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagService.java
@@ -1,4 +1,17 @@
 package com.todoay.api.domain.hashtag.service;
 
+import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+
 public interface HashtagService {
+
+
+    // 검색해서 5개를 미리 출력한다.
+    HashtagAutoCompleteResponseDto searchHashtagAutoComplete(String name);
+
+    // 페이지로 검색하기
+
+    HashtagSearchResopnseDto searchHashtag(String name, int pageNum);
+
+
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagService.java
@@ -1,7 +1,7 @@
 package com.todoay.api.domain.hashtag.service;
 
 import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
-import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResponseDto;
 
 public interface HashtagService {
 
@@ -11,7 +11,7 @@ public interface HashtagService {
 
     // 페이지로 검색하기
 
-    HashtagSearchResopnseDto searchHashtag(String name, int pageNum);
+    HashtagSearchResponseDto searchHashtag(String name, int pageNum);
 
 
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
@@ -7,6 +7,7 @@ import com.todoay.api.domain.hashtag.dto.HashtagSearchResponseDto;
 import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.hashtag.exception.NoMoreDataException;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
+import com.todoay.api.domain.todo.entity.DaliyTodo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 @Slf4j
@@ -48,5 +50,22 @@ public class HashtagServiceImpl implements HashtagService{
 
 
         return new HashtagSearchResponseDto(page.hasNext(), page.getNumber()+1,infoDtos);
+    }
+
+    public void testCode() {
+        DaliyTodo daliyTodo = new DaliyTodo(); // 새로 생성 or find한 Todo 객체
+        List<HashtagInfoDto> names = new ArrayList<>(); // DTO로 부터 받은 hashtag name 리스트
+        List<Hashtag> tags = new ArrayList<>(); // dailyTodo로 전달할 list객체, 연관관계 메서드를 개별 Hashtag로 변경하면
+                                                // 아래 코드를 더 줄일 수 있음.
+        names.forEach(n -> {
+            String name = n.getName();
+            hashtagRepository.findByName(name)
+                    .ifPresentOrElse(tags::add, // 검색 결과가 존재한다면 연관 관계를 맺을 리스트에 추가
+                            () ->{
+                        Hashtag save = hashtagRepository.save(new Hashtag(n.getName())); // 없다면 DB에 저장하고 저장.
+                        tags.add(save);
+                    });
+        });
+        daliyTodo.associateWithHashtag(tags); // 연관관계를 맺음.
     }
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
@@ -1,15 +1,52 @@
 package com.todoay.api.domain.hashtag.service;
 
 
+import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import com.todoay.api.domain.hashtag.exception.NoMoreDataException;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = false)
 @Service
 public class HashtagServiceImpl implements HashtagService{
 
     private final HashtagRepository hashtagRepository;
+
+    @Override
+    public HashtagAutoCompleteResponseDto searchHashtagAutoComplete(String name) {
+        List<Hashtag> hashtags = hashtagRepository.findTop5ByNameStartsWith(name);
+        List<HashtagInfoDto> infoDtos = hashtags.stream()
+                .map(HashtagInfoDto::new)
+                .collect(Collectors.toList());
+
+        return new HashtagAutoCompleteResponseDto(infoDtos);
+    }
+
+    @Override
+    public HashtagSearchResopnseDto searchHashtag(String name, int pageNum) {
+        PageRequest pageRequest = PageRequest.of(pageNum, 5);
+
+        Slice<Hashtag> page = hashtagRepository.findHashtagByNameStartsWith(name, pageRequest);
+        List<HashtagInfoDto> infoDtos = page.getContent().stream()
+                .map(HashtagInfoDto::new)
+                .collect(Collectors.toList());
+        log.info("list = {}",infoDtos);
+        if(infoDtos.isEmpty())
+            throw new NoMoreDataException();
+
+
+        return new HashtagSearchResopnseDto(page.hasNext(), page.getNumber()+1,infoDtos);
+    }
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
@@ -3,7 +3,7 @@ package com.todoay.api.domain.hashtag.service;
 
 import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
-import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResponseDto;
 import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.hashtag.exception.NoMoreDataException;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
@@ -35,7 +35,7 @@ public class HashtagServiceImpl implements HashtagService{
     }
 
     @Override
-    public HashtagSearchResopnseDto searchHashtag(String name, int pageNum) {
+    public HashtagSearchResponseDto searchHashtag(String name, int pageNum) {
         PageRequest pageRequest = PageRequest.of(pageNum, 5);
 
         Slice<Hashtag> page = hashtagRepository.findHashtagByNameStartsWith(name, pageRequest);
@@ -47,6 +47,6 @@ public class HashtagServiceImpl implements HashtagService{
             throw new NoMoreDataException();
 
 
-        return new HashtagSearchResopnseDto(page.hasNext(), page.getNumber()+1,infoDtos);
+        return new HashtagSearchResponseDto(page.hasNext(), page.getNumber()+1,infoDtos);
     }
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
@@ -51,21 +51,4 @@ public class HashtagServiceImpl implements HashtagService{
 
         return new HashtagSearchResponseDto(page.hasNext(), page.getNumber()+1,infoDtos);
     }
-
-    public void testCode() {
-        DaliyTodo daliyTodo = new DaliyTodo(); // 새로 생성 or find한 Todo 객체
-        List<HashtagInfoDto> names = new ArrayList<>(); // DTO로 부터 받은 hashtag name 리스트
-        List<Hashtag> tags = new ArrayList<>(); // dailyTodo로 전달할 list객체, 연관관계 메서드를 개별 Hashtag로 변경하면
-                                                // 아래 코드를 더 줄일 수 있음.
-        names.forEach(n -> {
-            String name = n.getName();
-            hashtagRepository.findByName(name)
-                    .ifPresentOrElse(tags::add, // 검색 결과가 존재한다면 연관 관계를 맺을 리스트에 추가
-                            () ->{
-                        Hashtag save = hashtagRepository.save(new Hashtag(n.getName())); // 없다면 DB에 저장하고 저장.
-                        tags.add(save);
-                    });
-        });
-        daliyTodo.associateWithHashtag(tags); // 연관관계를 맺음.
-    }
 }

--- a/src/main/java/com/todoay/api/domain/todo/service/TodoService.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/TodoService.java
@@ -1,0 +1,8 @@
+package com.todoay.api.domain.todo.service;
+
+public interface TodoService {
+
+    void save();
+
+    void update();
+}

--- a/src/main/java/com/todoay/api/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/TodoServiceImpl.java
@@ -1,0 +1,29 @@
+package com.todoay.api.domain.todo.service;
+
+import com.todoay.api.domain.hashtag.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service @Transactional
+public class TodoServiceImpl implements TodoService{
+
+
+    private final HashtagRepository hashtagRepository;
+
+    @Override
+    public void save() {
+
+        // 해시 태그 names 리스트로 추출
+        // 존재하는지 체크.
+        // 존재 안한다면 생성. 및 association 걸기.
+
+
+    }
+
+    @Override
+    public void update() {
+
+    }
+}

--- a/src/main/java/com/todoay/api/global/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/todoay/api/global/config/GlobalExceptionHandler.java
@@ -9,12 +9,17 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+import java.lang.reflect.Method;
 import java.sql.SQLIntegrityConstraintViolationException;
 
 import static com.todoay.api.global.exception.GlobalErrorCode.*;
@@ -38,6 +43,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleSqlIntegrityConstraintViolationException(SQLIntegrityConstraintViolationException ex, HttpServletRequest request) {
         return ErrorResponse.toResponseEntity(SQL_INTEGRITY_CONSTRAINT_VIOLATION, request.getRequestURI());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException ex, HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(REQUEST_PARAM_CONSTRAINT_VIOLATION, request.getRequestURI());
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex, HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(REQUEST_PARAM_MISSING, request.getRequestURI());
+    }
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(REQUEST_PARAM_TYPE_MISMATCH, request.getRequestURI());
     }
 
     @ExceptionHandler(ExpiredJwtException.class)

--- a/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
@@ -14,7 +14,13 @@ public enum GlobalErrorCode implements ErrorCode{
     JWT_UNSUPPORTED(HttpStatus.FORBIDDEN, "지원하지 않는 종류의 토큰입니다."),
     JWT_HEADER_NOT_FOUND(HttpStatus.FORBIDDEN, "JWT을 담은 Request Header가 존재하지 않습니다."), // v
 
-    SQL_INTEGRITY_CONSTRAINT_VIOLATION(HttpStatus.FORBIDDEN,"DB 제약조건을 위반하였습니다.")
+    SQL_INTEGRITY_CONSTRAINT_VIOLATION(HttpStatus.FORBIDDEN,"DB 제약조건을 위반하였습니다."),
+
+    REQUEST_PARAM_CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "리퀘스트 파라미터가 제약 조건을 위반하였습니다."),
+
+    REQUEST_PARAM_MISSING(HttpStatus.BAD_REQUEST,"요구되는 리퀘스트 파라미터가 존재하지 않습니다."),
+
+    REQUEST_PARAM_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "리퀘스트 파라미터의 타입이 올바르지 않습니다.")
 
 
     ;

--- a/src/main/java/com/todoay/api/global/init/InitialData.java
+++ b/src/main/java/com/todoay/api/global/init/InitialData.java
@@ -1,6 +1,7 @@
 package com.todoay.api.global.init;
 
 import com.todoay.api.domain.auth.entity.Auth;
+import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.profile.entity.Profile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,14 @@ public class InitialData {
         testAuth.completeEmailVerification();
 
         em.persist(testAuth);
+
+
+        for (int i = 0; i < 10; i++) {
+            Hashtag hashtag = new Hashtag("#태그" + i);
+            em.persist(hashtag);
+        }
+
+
         tx.commit();
 
     }

--- a/src/test/java/com/todoay/api/domain/hashtag/controller/HashtagControllerTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/controller/HashtagControllerTest.java
@@ -1,0 +1,7 @@
+package com.todoay.api.domain.hashtag.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HashtagControllerTest {
+
+}

--- a/src/test/java/com/todoay/api/domain/hashtag/repository/HashtagRepositoryTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/repository/HashtagRepositoryTest.java
@@ -25,7 +25,7 @@ class HashtagRepositoryTest {
     @BeforeEach
     void beforeEach() {
         for (int i = 0; i < 20; i++) {
-            Hashtag h1 = new Hashtag("#태그"+i);
+            Hashtag h1 = new Hashtag("#tag"+i);
             repository.save(h1);
         }
     }
@@ -38,7 +38,7 @@ class HashtagRepositoryTest {
 
     @Test
     void autoComplete_size_test() {
-        List<Hashtag> tags = repository.findTop5ByNameStartsWith("#태그");
+        List<Hashtag> tags = repository.findTop5ByNameStartsWith("#tag");
         assertThat(tags.size()).isSameAs(5);
     }
 
@@ -46,7 +46,7 @@ class HashtagRepositoryTest {
     void search_first_test() {
 
         PageRequest request = PageRequest.of(0,5);
-        String name = "#태그";
+        String name = "#tag";
 
         Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
         List<Hashtag> content = tags.getContent();
@@ -60,7 +60,7 @@ class HashtagRepositoryTest {
     @Test
     void search_next_test() {
         PageRequest request = PageRequest.of(1,5);
-        String name = "#태그";
+        String name = "#tag";
 
         Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
         List<Hashtag> content = tags.getContent();
@@ -73,7 +73,7 @@ class HashtagRepositoryTest {
     @Test
     void search_no_more_search_exception() {
         PageRequest request = PageRequest.of(10,5);
-        String name = "#태그";
+        String name = "#tag";
 
         Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
         List<Hashtag> content = tags.getContent();

--- a/src/test/java/com/todoay/api/domain/hashtag/repository/HashtagRepositoryTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/repository/HashtagRepositoryTest.java
@@ -1,0 +1,89 @@
+package com.todoay.api.domain.hashtag.repository;
+
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class HashtagRepositoryTest {
+
+
+    @Autowired
+    HashtagRepository repository;
+
+    @BeforeEach
+    void beforeEach() {
+        for (int i = 0; i < 20; i++) {
+            Hashtag h1 = new Hashtag("#태그"+i);
+            repository.save(h1);
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        repository.deleteAll();
+    }
+
+
+    @Test
+    void autoComplete_size_test() {
+        List<Hashtag> tags = repository.findTop5ByNameStartsWith("#태그");
+        assertThat(tags.size()).isSameAs(5);
+    }
+
+    @Test
+    void search_first_test() {
+
+        PageRequest request = PageRequest.of(0,5);
+        String name = "#태그";
+
+        Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
+        List<Hashtag> content = tags.getContent();
+
+        assertThat(tags.hasNext()).isTrue();
+        assertThat(tags.getNumber()).isSameAs(0);
+        assertThat(content.size()).isSameAs(5);
+
+    }
+
+    @Test
+    void search_next_test() {
+        PageRequest request = PageRequest.of(1,5);
+        String name = "#태그";
+
+        Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
+        List<Hashtag> content = tags.getContent();
+
+        assertThat(tags.hasNext()).isTrue();
+        assertThat(tags.getNumber()).isSameAs(1);
+        assertThat(content.size()).isSameAs(5);
+    }
+
+    @Test
+    void search_no_more_search_exception() {
+        PageRequest request = PageRequest.of(10,5);
+        String name = "#태그";
+
+        Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
+        List<Hashtag> content = tags.getContent();
+        assertThat(tags.hasNext()).isFalse();
+        assertThat(tags.getNumber()).isNotSameAs(1);
+        assertThat(content.size()).isNotSameAs(5);
+
+
+    }
+
+
+
+}

--- a/src/test/java/com/todoay/api/domain/hashtag/service/HashtagServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/service/HashtagServiceImplTest.java
@@ -1,0 +1,80 @@
+package com.todoay.api.domain.hashtag.service;
+
+import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import com.todoay.api.domain.hashtag.exception.NoMoreDataException;
+import com.todoay.api.domain.hashtag.repository.HashtagRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+class HashtagServiceImplTest {
+
+    @Autowired HashtagService hashtagService;
+    @Autowired
+    HashtagRepository repository;
+
+    String name = "#태그";
+
+    @BeforeEach
+    void beforeEach() {
+        for (int i = 0; i < 20; i++) {
+            Hashtag h1 = new Hashtag("#태그"+i);
+            repository.save(h1);
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        repository.deleteAll();
+    }
+
+
+    @Test
+    void autoComplete_test() {
+
+        HashtagAutoCompleteResponseDto dto = hashtagService.searchHashtagAutoComplete(name);
+        List<HashtagInfoDto> infos = dto.getInfos();
+
+        assertThat(infos).hasSize(5);
+    }
+
+    @Test
+    void search_test() {
+
+        HashtagSearchResopnseDto dto = hashtagService.searchHashtag(name, 0);
+        List<HashtagInfoDto> infos = dto.getInfos();
+        int nextPage = dto.getNextPage();
+        boolean hasNext = dto.isHasNext();
+
+        assertThat(hasNext).isTrue();
+        assertThat(nextPage).isSameAs(1);
+        assertThat(infos).hasSize(5);
+
+    }
+
+    @Test
+    void search_test_exception_page() {
+        assertThatThrownBy(() -> hashtagService.searchHashtag(name, 1000))
+                .isInstanceOf(NoMoreDataException.class);
+    }
+
+    @Test
+    void search_test_exception_name() {
+        assertThatThrownBy(() -> hashtagService.searchHashtag("qwecqwceqwecqwec", 0))
+                .isInstanceOf(NoMoreDataException.class);
+    }
+
+}

--- a/src/test/java/com/todoay/api/domain/hashtag/service/HashtagServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/service/HashtagServiceImplTest.java
@@ -2,11 +2,10 @@ package com.todoay.api.domain.hashtag.service;
 
 import com.todoay.api.domain.hashtag.dto.HashtagAutoCompleteResponseDto;
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
-import com.todoay.api.domain.hashtag.dto.HashtagSearchResopnseDto;
+import com.todoay.api.domain.hashtag.dto.HashtagSearchResponseDto;
 import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.hashtag.exception.NoMoreDataException;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 
 @SpringBootTest
@@ -54,9 +52,9 @@ class HashtagServiceImplTest {
     @Test
     void search_test() {
 
-        HashtagSearchResopnseDto dto = hashtagService.searchHashtag(name, 0);
+        HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, 0);
         List<HashtagInfoDto> infos = dto.getInfos();
-        int nextPage = dto.getNextPage();
+        int nextPage = dto.getNextPageNum();
         boolean hasNext = dto.isHasNext();
 
         assertThat(hasNext).isTrue();


### PR DESCRIPTION
해시태그 검색 기능과 해시태그 검색 미리보기 기능을 추가함.

1. 해시태그 미리보기 검색
-> 클라이언트가 검색창에서 해시태그 이름을 검색할 때마다N개씩 (현재는 5개) 출력해서 리스트 형태로 보여준다.
URL : [GET]/hashtag/auto?name=~~~~
![image](https://user-images.githubusercontent.com/76154390/183114395-1cad6595-1eec-4848-91b3-258b3b0e32d8.png)

2.해시태그 검색 기능
-> 클라이언트가 검색을 했을 때 N개를 출력하여 리스트 형태로 보여준다. 페이지 번호를 입력하여 요청을 보내기 때문에, 해당 페이지에 맞는 정보를 출력함. 
응답에는 다음 페이지의 유무와 다음 페이지 번호가 같이 담긴다. 
URL : [GET]/hashtag?name=~~~&pageNum=~~~
![image](https://user-images.githubusercontent.com/76154390/183114641-9fc8ce93-237a-4b26-8e9c-0dc97983cda5.png)


---- 리퀘스트 파라미터 검증 추가 예정 ----
