### PR TITLE
해시태그 추가, 수정 기능 추가

### DIFF
--- a/src/main/java/com/todoay/api/domain/auth/entity/Auth.java
+++ b/src/main/java/com/todoay/api/domain/auth/entity/Auth.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -65,6 +66,19 @@ public class Auth implements UserDetails {
         this.deletedAt = LocalDateTime.now();
         email = UUID.randomUUID().toString();
         profile.delete();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Auth auth = (Auth) o;
+        return id.equals(auth.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     @Override // 계정이 가지고 있는 권한 목록 리턴

--- a/src/main/java/com/todoay/api/domain/category/service/CategoryCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/category/service/CategoryCRUDServiceImpl.java
@@ -7,9 +7,10 @@ import com.todoay.api.domain.category.exception.NotYourCategoryException;
 import com.todoay.api.domain.category.repository.CategoryRepository;
 import com.todoay.api.global.context.LoginAuthContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -20,6 +21,7 @@ public class CategoryCRUDServiceImpl implements CategoryCRUDService {
 
     @Override
     public CategorySaveResponseDto addCategory(CategorySaveRequestDto dto) {
+        log.info("Category-addCategory - Auth = {}",loginAuthContext.getLoginAuth());
         return new CategorySaveResponseDto(categoryRepository.save(new Category(dto.getName(), dto.getColor(), dto.getOrderIndex(), loginAuthContext.getLoginAuth())).getId());
     }
 

--- a/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
@@ -11,10 +11,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/todo")
@@ -34,6 +35,7 @@ public class TodoController {
             }
     )
     public ResponseEntity<DailyTodoSaveResponseDto> dailyTodoSave(@RequestBody @Validated DailyTodoSaveRequestDto dailyTodoSaveRequestDto) {
+        log.info("hashtags = {}",dailyTodoSaveRequestDto.getHashtagNames());
         DailyTodoSaveResponseDto dailyTodoSaveResponseDto = dailyTodoCRUDService.addTodo(dailyTodoSaveRequestDto);
         return ResponseEntity.ok(dailyTodoSaveResponseDto);
     }

--- a/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
@@ -31,7 +31,8 @@ public class TodoController {
             responses = {
                     @ApiResponse(responseCode = "201"),  // 요청이 수용되어 리소스가 만들어졌을 때
                     @ApiResponse(responseCode = "400", description = "올바른 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
-                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "카테고리가 로그인 유저의 것이 아님", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     public ResponseEntity<DailyTodoSaveResponseDto> dailyTodoSave(@RequestBody @Validated DailyTodoSaveRequestDto dailyTodoSaveRequestDto) {
@@ -87,7 +88,7 @@ public class TodoController {
 
     @PutMapping("/due-date/{id}")
     @Operation(
-            summary = "로그인 유저의 DailyTodo를 수정한다.",
+            summary = "로그인 유저의 due-dateTodo를 수정한다.",
             responses = {
                     @ApiResponse(responseCode = "201"),  // 요청이 수용되어 리소스가 만들어졌을 때
                     @ApiResponse(responseCode = "400", description = "올바른 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),

--- a/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoModifyRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoModifyRequestDto.java
@@ -1,18 +1,19 @@
 package com.todoay.api.domain.todo.dto;
 
-import com.todoay.api.domain.auth.entity.Auth;
-import com.todoay.api.domain.category.entity.Category;
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
 import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
 public class DailyTodoModifyRequestDto {
-    // Todo 공통 속성
+    // 투두 공통 속성
     @NotNull
     private String title;
     private String description = "내용 없음";
@@ -27,4 +28,6 @@ public class DailyTodoModifyRequestDto {
     @NotNull
     private LocalDate dailyDate;
     private Long categoryId;
+
+    private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
 }

--- a/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoSaveRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoSaveRequestDto.java
@@ -1,19 +1,20 @@
 package com.todoay.api.domain.todo.dto;
 
-import com.todoay.api.domain.auth.entity.Auth;
-import com.todoay.api.domain.category.entity.Category;
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
 import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Data
 @Builder
 public class DailyTodoSaveRequestDto {
-    // Todo 공통 속성
+    // 투두 공통 속성
     @NotNull
     private String title;
     private String description = "내용 없음";
@@ -29,6 +30,9 @@ public class DailyTodoSaveRequestDto {
     private LocalDate dailyDate;
     @NotNull
     private Long categoryId;
+
+    // hashtag
+    private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
 
 
 }

--- a/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoModifyRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoModifyRequestDto.java
@@ -1,11 +1,15 @@
 package com.todoay.api.domain.todo.dto;
 
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
 import com.todoay.api.domain.todo.entity.Importance;
 import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 @Builder
 public class DueDateTodoModifyRequestDto {
@@ -19,4 +23,7 @@ public class DueDateTodoModifyRequestDto {
     @NotNull
     private LocalDate dueDate;
     private String importance;
+
+    // hashtag
+    private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
 }

--- a/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoSaveRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoSaveRequestDto.java
@@ -1,11 +1,14 @@
 package com.todoay.api.domain.todo.dto;
 
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
 import com.todoay.api.domain.todo.entity.Importance;
 import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -20,4 +23,7 @@ public class DueDateTodoSaveRequestDto {
     @NotNull
     private LocalDate dueDate;
     private String importance;
+
+    // hashtag
+    private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
 }

--- a/src/main/java/com/todoay/api/domain/todo/entity/DailyTodo.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/DailyTodo.java
@@ -18,9 +18,9 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 public class DailyTodo extends Todo{
-
+    @JsonFormat(shape = JsonFormat.Shape.STRING,pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime alarm;
-
+    @JsonFormat(shape = JsonFormat.Shape.STRING,pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime targetTime;
     private String place;
     private String people;
@@ -60,6 +60,6 @@ public class DailyTodo extends Todo{
         this.place = place;
         this.people = people;
         this.dailyDate = dailyDate;
-        this.category = category;;
+        this.category = category;
     }
 }

--- a/src/main/java/com/todoay/api/domain/todo/entity/Todo.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/Todo.java
@@ -40,6 +40,7 @@ public abstract class Todo {
     // 연관관계 메소드
     public void associateWithHashtag(List<Hashtag> hashtags) {
         // hashtag를 받아와서 todohashtag를 만들고 이걸 설정해준다.
+        this.todoHashtags.clear();
         for (Hashtag hashtag : hashtags) {
             TodoHashtag todoHashtag = TodoHashtag.builder()
                     .todo(this)

--- a/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
@@ -65,11 +65,8 @@ public class DailyTodoCRUDServiceImpl implements DailyTodoCRUDService{
     }
 
     private List<Hashtag> getHashtagsByHashtagNames(List<HashtagInfoDto> hashtagNames) {
-
-        List<HashtagInfoDto> names = hashtagNames;
         List<Hashtag> tags = new ArrayList<>(); // dailyTodo로 전달할 list객체, 연관관계 메서드를 개별 Hashtag로 변경하면
-        // 아래 코드를 더 줄일 수 있음.
-        names.forEach(n -> {
+        hashtagNames.forEach(n -> {
             String name = n.getName();
             hashtagRepository.findByName(name)
                     .ifPresentOrElse(tags::add, // 검색 결과가 존재한다면 연관 관계를 맺을 리스트에 추가

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
@@ -5,6 +5,9 @@ import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.category.entity.Category;
 import com.todoay.api.domain.category.exception.CategoryNotFoundException;
 import com.todoay.api.domain.category.exception.NotYourCategoryException;
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import com.todoay.api.domain.hashtag.repository.HashtagRepository;
 import com.todoay.api.domain.todo.dto.DueDateTodoModifyRequestDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoSaveRequestDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoSaveResponseDto;
@@ -19,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,22 +33,23 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
     private final JwtProvider jwtProvider;
 
     private final LoginAuthContext loginAuthContext;
+    private final HashtagRepository hashtagRepository;
 
 
     @Override
     public DueDateTodoSaveResponseDto addTodo(DueDateTodoSaveRequestDto dto) {
         Auth auth = authRepository.findByEmail(jwtProvider.getLoginId()).get();
-        DueDateTodo dueDateTodo = dueDateTodoRepository.save(
-                DueDateTodo.builder()
-                        .title(dto.getTitle())
-                        .isPublic(dto.isPublic())
-                        .isFinished(false)
-                        .dueDate(dto.getDueDate())
-                        .description(dto.getDescription())
-                        .importance(Importance.valueOf(dto.getImportance().toUpperCase()))
-                        .auth(auth)
-                        .build()
-        );
+        DueDateTodo dueDateTodo = DueDateTodo.builder()
+                .title(dto.getTitle())
+                .isPublic(dto.isPublic())
+                .isFinished(false)
+                .dueDate(dto.getDueDate())
+                .description(dto.getDescription())
+                .importance(Importance.valueOf(dto.getImportance().toUpperCase()))
+                .auth(auth)
+                .build();
+        dueDateTodo.associateWithHashtag(getHashtagsByHashtagNames(dto.getHashtagNames()));
+        dueDateTodoRepository.save(dueDateTodo);
         return DueDateTodoSaveResponseDto.builder().id(dueDateTodo.getId()).build();
     }
 
@@ -52,6 +58,7 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
     public void modifyDueDateTodo(Long id, DueDateTodoModifyRequestDto dto) {
         DueDateTodo dueDateTodo = checkIsPresentAndIsMineAndGetTodo(id);
         dueDateTodo.modify(dto.getTitle(), dto.isPublic(),dto.isFinished(), dto.getDueDate(), dto.getDescription(),Importance.valueOf(dto.getImportance().toUpperCase()));
+        dueDateTodo.associateWithHashtag(getHashtagsByHashtagNames(dto.getHashtagNames()));
     }
 
     @Transactional
@@ -74,4 +81,17 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
         return dueDateTodoRepository.findById(id).orElseThrow(TodoNotFoundException::new);
     }
 
+    private List<Hashtag> getHashtagsByHashtagNames(List<HashtagInfoDto> hashtagNames) {
+        List<Hashtag> tags = new ArrayList<>(); // dailyTodo로 전달할 list객체, 연관관계 메서드를 개별 Hashtag로 변경하면
+        hashtagNames.forEach(n -> {
+            String name = n.getName();
+            hashtagRepository.findByName(name)
+                    .ifPresentOrElse(tags::add, // 검색 결과가 존재한다면 연관 관계를 맺을 리스트에 추가
+                            () ->{
+                                Hashtag save = hashtagRepository.save(new Hashtag(n.getName())); // 없다면 DB에 저장하고 저장.
+                                tags.add(save);
+                            });
+        });
+        return tags;
+    }
 }

--- a/src/main/java/com/todoay/api/domain/todo/utility/HashtagAttacher.java
+++ b/src/main/java/com/todoay/api/domain/todo/utility/HashtagAttacher.java
@@ -1,0 +1,27 @@
+package com.todoay.api.domain.todo.utility;
+
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import com.todoay.api.domain.hashtag.repository.HashtagRepository;
+import com.todoay.api.domain.todo.entity.Todo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface HashtagAttacher {
+
+    public static Todo attachHashtag(Todo todo, List<HashtagInfoDto> hashtagNames, HashtagRepository hashtagRepository){
+        List<Hashtag> hashtags = getHashtagsByHashtagNames(hashtagNames, hashtagRepository);
+        todo.associateWithHashtag(hashtags);
+        return todo;
+    }
+
+    private static List<Hashtag> getHashtagsByHashtagNames(List<HashtagInfoDto> hashtagNames, HashtagRepository hashtagRepository) {
+        List<Hashtag> tags = new ArrayList<>(); // dailyTodo로 전달할 list객체, 연관관계 메서드를 개별 Hashtag로 변경하면
+        hashtagNames.forEach(n -> hashtagRepository.findByName(n.getName())
+                .ifPresentOrElse(tags::add, // 검색 결과가 존재한다면 연관 관계를 맺을 리스트에 추가
+                        () -> tags.add(hashtagRepository.save(new Hashtag(n.getName()))) // 없다면 DB에 저장하고 저장.
+                ));
+        return tags;
+    }
+}

--- a/src/main/java/com/todoay/api/domain/todo/utility/HashtagAttacher.java
+++ b/src/main/java/com/todoay/api/domain/todo/utility/HashtagAttacher.java
@@ -5,8 +5,8 @@ import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
 import com.todoay.api.domain.todo.entity.Todo;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public interface HashtagAttacher {
 
@@ -17,11 +17,8 @@ public interface HashtagAttacher {
     }
 
     private static List<Hashtag> getHashtagsByHashtagNames(List<HashtagInfoDto> hashtagNames, HashtagRepository hashtagRepository) {
-        List<Hashtag> tags = new ArrayList<>(); // dailyTodo로 전달할 list객체, 연관관계 메서드를 개별 Hashtag로 변경하면
-        hashtagNames.forEach(n -> hashtagRepository.findByName(n.getName())
-                .ifPresentOrElse(tags::add, // 검색 결과가 존재한다면 연관 관계를 맺을 리스트에 추가
-                        () -> tags.add(hashtagRepository.save(new Hashtag(n.getName()))) // 없다면 DB에 저장하고 저장.
-                ));
-        return tags;
+        return hashtagNames.stream().map(n-> hashtagRepository.findByName(n.getName())
+                .orElseGet(() -> hashtagRepository.save(new Hashtag(n.getName())))
+            ).collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/todoay/api/domain/category/service/CategoryCRUDServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/category/service/CategoryCRUDServiceImplTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,8 @@ class CategoryCRUDServiceImplTest {
 
     @Autowired CategoryCRUDService categoryCRUDService;
 
+
+    @Autowired LoginAuthContext context;
     @Autowired
     EntityManager em;
 
@@ -48,6 +51,17 @@ class CategoryCRUDServiceImplTest {
 
     void login(Auth auth) {
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(auth, "", auth.getAuthorities()));
+        System.out.println(testAuth1);
+        Auth p = (Auth)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println(p);
+
+
+    }
+
+    void login2(Auth auth) {
+        Auth auth2 = authRepository.findById(auth.getId()).get();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(auth2, "", auth2.getAuthorities()));
+
     }
 
     @Test
@@ -254,5 +268,34 @@ class CategoryCRUDServiceImplTest {
 
         // then
         Assertions.assertThrows(NotYourCategoryException.class, () -> categoryCRUDService.endCategory(categoryId1));
+    }
+
+    @Test
+    void categoryAuthEqualLoginAuth() {
+        String name = "category_name";
+        String color = "#123123";
+        Integer orderIndex = 1;
+        Long categoryId1 = categoryCRUDService.addCategory(CategorySaveRequestDto.builder().name(name).color(color).orderIndex(orderIndex).build()).getId();
+//        em.flush();
+//        em.clear();
+        Category findedCategory = categoryRepository.findById(categoryId1).get();
+
+
+
+
+
+//        login2(testAuth1);
+//
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        Auth auth = (Auth) authentication.getPrincipal();
+        Auth p = (Auth)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println("testAuth1 = " + testAuth1);
+        System.out.println("p = " + p);
+        System.out.println("findedCategory.getAuth() = " + findedCategory.getAuth());
+        org.assertj.core.api.Assertions.assertThat(testAuth1).isEqualTo(findedCategory.getAuth());
+
+//        System.out.println(auth);
+//        System.out.println(findedCategory.getAuth());
+
     }
 }

--- a/src/test/java/com/todoay/api/domain/todo/utility/HashtagAttacherTest.java
+++ b/src/test/java/com/todoay/api/domain/todo/utility/HashtagAttacherTest.java
@@ -1,0 +1,69 @@
+package com.todoay.api.domain.todo.utility;
+
+import com.todoay.api.domain.hashtag.entity.Hashtag;
+import com.todoay.api.domain.hashtag.repository.HashtagRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class HashtagAttacherTest {
+
+    Map<String, Optional<String>> testerMap = new HashMap<>();
+
+
+    @Autowired
+    HashtagRepository repository;
+
+    @BeforeEach
+    void beforeEach() {
+        testerMap.put("t1",Optional.of("t1"));
+        testerMap.put("t2",Optional.of("t2"));
+        testerMap.put("t3",Optional.of("t3"));
+    }
+
+    @Test
+    void optionalTest() {
+        String find = testerMap.get("t1").orElse("hello");
+        assertThat(find).isEqualTo("t1");
+
+    }
+    @Test
+    void optionalTest2() {
+        String find = testerMap.getOrDefault("t13333",Optional.empty()).orElse("hello");
+        assertThat(find).isEqualTo("hello");
+
+    }
+
+    @Test
+    void hashtagOptionalTest() {
+        String t1 = "#태그1";
+        String t3 = "#태그2";
+        List<String> names = new ArrayList<>();
+        names.add(t1);
+        names.add(t3);
+
+
+
+
+        System.out.println("before : " + repository.count());
+        for (String name : names) {
+            boolean present = repository.findByName(name).isPresent();
+            System.out.println("present = " + present);
+            Hashtag hashtag = repository.findByName(name).orElseGet(() -> repository.save(new Hashtag(name)));
+            System.out.println(String.format("hashtag id : %d, name : %s", hashtag.getId(),hashtag.getName()));
+        }
+
+        System.out.println("after : " + repository.count());
+        assertThat(repository.count()).isSameAs(10L);
+
+    }
+
+}


### PR DESCRIPTION
### 개요

daily-todo와 due-date-todo의 추가, 수정 기능에서 dto를 통해서 hashtag의 이름을 받아온 후, 해당 이름을 조회하여 todo에 추가해주는 기능을 추가하였다.

### 로직

1. 각 DTO에 List<HashtagInfoDto> 추가.
2. Service계층에서 todo가 생성자에 의해서 생성된 이후, HashtagAttacher의 attachHashtag메서드로 todo, DTO로 받은 해시태그정보, hashtagRepository 전달.
3. HastagAttacher는 전달 받은 리스트를 리포지토리를 통해 조회하고, 조회되지 않은 경우엔 그 이름을 지닌 해시태그를 새로이 저장해준다.
4. HashtagAttacher는 조회, 저장 작업이 끝난 이후 Hashtag Entity를 TODO의 associateWithHashtag 메서드를 사용해 연관관게를 형성한다.
5. HashtagAttacher는 TODO를 반환해주고, 기존 서비스는 본래 작업을 이어서 진행한다.


### DB 저장 결과

![image](https://user-images.githubusercontent.com/76154390/184808080-504fd990-b28c-4bed-83cc-74919cf4ce10.png)


#### #140  관련 문제 Equals 메서드 재정의
id가 같으면 같은 것으로 설정해주었음.
```
  @Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (o == null || getClass() != o.getClass()) return false;
        Auth auth = (Auth) o;
        return id.equals(auth.id);
    }

    @Override
    public int hashCode() {
        return Objects.hash(id);
    }
```