### PR TITLE
Due-Date Todo 조회 기능 추가

### DIFF
--- a/src/main/java/com/todoay/api/domain/category/dto/CategorySaveRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/category/dto/CategorySaveRequestDto.java
@@ -2,13 +2,15 @@ package com.todoay.api.domain.category.dto;
 
 import com.todoay.api.global.customValidation.annotation.ValidationCategoryColor;
 import com.todoay.api.global.customValidation.annotation.ValidationCategoryName;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 @Data
-@Builder
+@Builder @NoArgsConstructor @AllArgsConstructor
 public class CategorySaveRequestDto {
     @ValidationCategoryName
     private String name;

--- a/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
@@ -161,6 +161,18 @@ public class TodoController {
         return ResponseEntity.ok(dueDateTodoSaveResponseDto);
     }
 
+    @GetMapping("/due-date/my")
+    public ResponseEntity<List<DueDateTodoReadResponseDto>> readDueDateTodoOrderByQueryString(@RequestParam("order") String order) {
+        List<DueDateTodoReadResponseDto> dtos = null;
+        if(order.equalsIgnoreCase("duedate")) {
+            dtos = dueDateTodoCRUDService.readTodosOrderByDueDate();
+        }else if(order.equalsIgnoreCase("importance"))
+            dtos = dueDateTodoCRUDService.readTodosOrderByImportance();
+        else
+            throw new IllegalArgumentException();
+        return ResponseEntity.ok(dtos);
+    }
+
     @PutMapping("/due-date/{id}")
     @Operation(
             summary = "로그인 유저의 due-dateTodo를 수정한다.",

--- a/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
@@ -53,14 +53,14 @@ public class TodoController {
             summary = "DailyTodo 단건 조회",
             description = "ID로 DailyTodo를 조회한다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DailyTodoReadResponseDto.class))),
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DailyTodoReadDetailResponseDto.class))),
                     @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "403", description = "id에 해당하는 TODO가 본인 것이 아니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "id에 해당하는 TODO가 존재하지 않는다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    public ResponseEntity<DailyTodoReadResponseDto> readDailyTodoById(@PathVariable("id") long id) {
-        DailyTodoReadResponseDto dto = dailyTodoCRUDService.readDailyTodoById(id);
+    public ResponseEntity<DailyTodoReadDetailResponseDto> readDailyTodoById(@PathVariable("id") long id) {
+        DailyTodoReadDetailResponseDto dto = dailyTodoCRUDService.readDailyTodoDetailById(id);
         return ResponseEntity.ok(dto);
     }
 
@@ -69,12 +69,12 @@ public class TodoController {
             summary = "DailyTodo 복수 조회",
             description = "특정 날짜에 대한 DailyTodo들을 조회한다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DailyTodoReadResponseDto.class))),
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DailyTodoReadDetailResponseDto.class))),
                     @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    public ResponseEntity<List<DailyTodoReadResponseDto>> readDailyTodosByDate(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
-        List<DailyTodoReadResponseDto> dtos = dailyTodoCRUDService.readDailyTodosByDate(localDate);
+    public ResponseEntity<List<DailyTodoReadDetailResponseDto>> readDailyTodosByDate(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
+        List<DailyTodoReadDetailResponseDto> dtos = dailyTodoCRUDService.readDailyTodosByDate(localDate);
         return ResponseEntity.ok(dtos);
     }
 
@@ -171,6 +171,11 @@ public class TodoController {
     public ResponseEntity<DueDateTodoReadDetailResponseDto> readDueDateTodoDetails(@PathVariable("id")Long id) {
         DueDateTodoReadDetailResponseDto dto = dueDateTodoCRUDService.readDueDateTodoDetail(id);
         return ResponseEntity.ok(dto);
+    }
+    @GetMapping("/due-date/my/finished")
+    public ResponseEntity<List<DueDateTodoReadResponseDto>> readFinishedDueDateTodo() {
+        List<DueDateTodoReadResponseDto> dtos = dueDateTodoCRUDService.readFinishedTodos();
+        return ResponseEntity.ok(dtos);
     }
 
     @PutMapping("/due-date/{id}")

--- a/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
@@ -163,14 +163,14 @@ public class TodoController {
 
     @GetMapping("/due-date/my")
     public ResponseEntity<List<DueDateTodoReadResponseDto>> readDueDateTodoOrderByQueryString(@RequestParam("order") String order) {
-        List<DueDateTodoReadResponseDto> dtos = null;
-        if(order.equalsIgnoreCase("duedate")) {
-            dtos = dueDateTodoCRUDService.readTodosOrderByDueDate();
-        }else if(order.equalsIgnoreCase("importance"))
-            dtos = dueDateTodoCRUDService.readTodosOrderByImportance();
-        else
-            throw new IllegalArgumentException();
+        List<DueDateTodoReadResponseDto> dtos = dueDateTodoCRUDService.readTodosOrderByCondition(order);
         return ResponseEntity.ok(dtos);
+    }
+
+    @GetMapping("/due-date/my/{id}")
+    public ResponseEntity<DueDateTodoReadDetailResponseDto> readDueDateTodoDetails(@PathVariable("id")Long id) {
+        DueDateTodoReadDetailResponseDto dto = dueDateTodoCRUDService.readDueDateTodoDetail(id);
+        return ResponseEntity.ok(dto);
     }
 
     @PutMapping("/due-date/{id}")

--- a/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/TodoController.java
@@ -26,8 +26,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/todo")
 public class TodoController {
-
-    private final TodoService todoService;
     private final DailyTodoCRUDService dailyTodoCRUDService;
     private final DueDateTodoCRUDService dueDateTodoCRUDService;
 
@@ -69,12 +67,12 @@ public class TodoController {
             summary = "DailyTodo 복수 조회",
             description = "특정 날짜에 대한 DailyTodo들을 조회한다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DailyTodoReadDetailResponseDto.class))),
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DailyTodoReadResponseDto.class))),
                     @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    public ResponseEntity<List<DailyTodoReadDetailResponseDto>> readDailyTodosByDate(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
-        List<DailyTodoReadDetailResponseDto> dtos = dailyTodoCRUDService.readDailyTodosByDate(localDate);
+    public ResponseEntity<List<DailyTodoReadResponseDto>> readDailyTodosByDate(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate) {
+        List<DailyTodoReadResponseDto> dtos = dailyTodoCRUDService.readDailyTodosByDate(localDate);
         return ResponseEntity.ok(dtos);
     }
 
@@ -161,17 +159,43 @@ public class TodoController {
         return ResponseEntity.ok(dueDateTodoSaveResponseDto);
     }
 
+    @Operation(
+            summary = "조건에 맞는 내 due-date Todo를 정렬해서 본다.",
+            description = "마감일, 중요도 중에서 선택해서 Due-Date TODO를 정렬하여 확인한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DueDateTodoReadResponseDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "올바르지 않은 ENUM값이 들어왔습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @GetMapping("/due-date/my")
     public ResponseEntity<List<DueDateTodoReadResponseDto>> readDueDateTodoOrderByQueryString(@RequestParam("order") String order) {
         List<DueDateTodoReadResponseDto> dtos = dueDateTodoCRUDService.readTodosOrderByCondition(order);
         return ResponseEntity.ok(dtos);
     }
-
+    @Operation(
+            summary = "Due-Date Todo를 디테일하게 본다.",
+            description = "ID에 해당하는 Due-Date Todo의 상세정보를 조회한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DueDateTodoReadDetailResponseDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "올바르지 않은 ENUM값이 들어왔습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 id의 리소스가 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @GetMapping("/due-date/my/{id}")
     public ResponseEntity<DueDateTodoReadDetailResponseDto> readDueDateTodoDetails(@PathVariable("id")Long id) {
         DueDateTodoReadDetailResponseDto dto = dueDateTodoCRUDService.readDueDateTodoDetail(id);
         return ResponseEntity.ok(dto);
     }
+    @Operation(
+            summary = "완료한 Due-Date Todo를 조회한다.",
+            description = "완료한 Due-Date Todo를 조회한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DueDateTodoReadResponseDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
     @GetMapping("/due-date/my/finished")
     public ResponseEntity<List<DueDateTodoReadResponseDto>> readFinishedDueDateTodo() {
         List<DueDateTodoReadResponseDto> dtos = dueDateTodoCRUDService.readFinishedTodos();

--- a/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoReadDetailResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoReadDetailResponseDto.java
@@ -1,0 +1,81 @@
+package com.todoay.api.domain.todo.dto;
+
+import com.todoay.api.domain.category.entity.Category;
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.todo.entity.DailyTodo;
+import com.todoay.api.domain.todo.entity.TodoHashtag;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class DailyTodoReadDetailResponseDto {
+
+
+    private Long id;
+    private String title;
+    private String description = "내용 없음";
+    private boolean isPublic = false;
+    private boolean isFinished = false;
+
+    // DailyTodo 속성
+    private LocalDateTime alarm;
+    private LocalDateTime targetTime;
+    private String place;
+    private String people;
+    @NotNull
+    private LocalDate dailyDate;
+    private CategoryInfoDto category;
+
+    private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
+
+    public static DailyTodoReadDetailResponseDto createReadResponseDto(DailyTodo dailyTodo) {
+
+        DailyTodoReadDetailResponseDto dto = injectTodoInfo(dailyTodo);
+        injectAssociatedInfo(dto, dailyTodo);
+        return dto;
+    }
+
+    private static DailyTodoReadDetailResponseDto injectTodoInfo(DailyTodo dailyTodo) {
+        DailyTodoReadDetailResponseDto dto = new DailyTodoReadDetailResponseDto();
+        dto.id = dailyTodo.getId();
+        dto.title = dailyTodo.getTitle();
+        String originDescription = dailyTodo.getDescription();
+        if (isStrNotNull(originDescription))
+            dto.description = originDescription;
+        dto.isPublic = dailyTodo.isPublic();
+        dto.isFinished = dailyTodo.isFinished();
+        dto.alarm = dailyTodo.getAlarm();
+        dto.targetTime = dailyTodo.getTargetTime();
+        if (isStrNotNull(dailyTodo.getPeople()))
+            dto.people = dailyTodo.getPeople();
+        if (isStrNotNull(dailyTodo.getPlace()))
+            dto.place = dailyTodo.getPlace();
+        dto.dailyDate = dailyTodo.getDailyDate();
+        return dto;
+    }
+
+    private static boolean isStrNotNull(String fieldValue) {
+        return fieldValue != null && !fieldValue.equals("null") && !fieldValue.isBlank();
+    }
+
+    private static void injectAssociatedInfo(DailyTodoReadDetailResponseDto dto, DailyTodo dailyTodo) {
+        injectCategoryInfo(dto, dailyTodo.getCategory());
+        injectHashtagInfo(dto, dailyTodo.getTodoHashtags());
+    }
+
+    private static void injectCategoryInfo(DailyTodoReadDetailResponseDto dto, Category category) {
+        dto.category = CategoryInfoDto.create(category);
+    }
+
+    private static void injectHashtagInfo(DailyTodoReadDetailResponseDto dto, List<TodoHashtag> hashtags) {
+        dto.hashtagNames = hashtags.stream().map(h ->
+                new HashtagInfoDto(h.getHashTag())
+        ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoReadResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoReadResponseDto.java
@@ -1,81 +1,37 @@
 package com.todoay.api.domain.todo.dto;
 
-import com.todoay.api.domain.category.entity.Category;
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
 import com.todoay.api.domain.todo.entity.DailyTodo;
-import com.todoay.api.domain.todo.entity.TodoHashtag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Data
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
 public class DailyTodoReadResponseDto {
-
 
     private Long id;
     private String title;
-    private String description = "내용 없음";
-    private boolean isPublic = false;
-    private boolean isFinished = false;
 
-    // DailyTodo 속성
-    private LocalDateTime alarm;
-    private LocalDateTime targetTime;
-    private String place;
-    private String people;
-    @NotNull
-    private LocalDate dailyDate;
-    private CategoryInfoDto category;
+    private CategoryInfoDto categoryInfoDto;
+    private List<HashtagInfoDto> hashtagInfoDtos = new ArrayList<>();
 
-    private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
+    public static DailyTodoReadResponseDto createDto(DailyTodo todo) {
 
-    public static DailyTodoReadResponseDto createReadResponseDto(DailyTodo dailyTodo) {
+        return DailyTodoReadResponseDto.builder()
+                .id(todo.getId())
+                .title(todo.getTitle())
+                .categoryInfoDto(CategoryInfoDto.create(todo.getCategory()))
+                .hashtagInfoDtos(todo.getTodoHashtags().stream()
+                        .map(th-> new HashtagInfoDto(th.getHashTag()))
+                        .collect(Collectors.toList()))
+                .build();
 
-        DailyTodoReadResponseDto dto = injectTodoInfo(dailyTodo);
-        injectAssociatedInfo(dto, dailyTodo);
-        return dto;
     }
 
-    private static DailyTodoReadResponseDto injectTodoInfo(DailyTodo dailyTodo) {
-        DailyTodoReadResponseDto dto = new DailyTodoReadResponseDto();
-        dto.id = dailyTodo.getId();
-        dto.title = dailyTodo.getTitle();
-        String originDescription = dailyTodo.getDescription();
-        if (isStrNotNull(originDescription))
-            dto.description = originDescription;
-        dto.isPublic = dailyTodo.isPublic();
-        dto.isFinished = dailyTodo.isFinished();
-        dto.alarm = dailyTodo.getAlarm();
-        dto.targetTime = dailyTodo.getTargetTime();
-        if (isStrNotNull(dailyTodo.getPeople()))
-            dto.people = dailyTodo.getPeople();
-        if (isStrNotNull(dailyTodo.getPlace()))
-            dto.place = dailyTodo.getPlace();
-        dto.dailyDate = dailyTodo.getDailyDate();
-        return dto;
-    }
 
-    private static boolean isStrNotNull(String fieldValue) {
-        return fieldValue != null && !fieldValue.equals("null") && !fieldValue.isBlank();
-    }
-
-    private static void injectAssociatedInfo(DailyTodoReadResponseDto dto, DailyTodo dailyTodo) {
-        injectCategoryInfo(dto, dailyTodo.getCategory());
-        injectHashtagInfo(dto, dailyTodo.getTodoHashtags());
-    }
-
-    private static void injectCategoryInfo(DailyTodoReadResponseDto dto, Category category) {
-        dto.category = CategoryInfoDto.create(category);
-    }
-
-    private static void injectHashtagInfo(DailyTodoReadResponseDto dto, List<TodoHashtag> hashtags) {
-        dto.hashtagNames = hashtags.stream().map(h ->
-                new HashtagInfoDto(h.getHashTag())
-        ).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoSaveRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DailyTodoSaveRequestDto.java
@@ -1,8 +1,10 @@
 package com.todoay.api.domain.todo.dto;
 
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -12,7 +14,8 @@ import java.util.List;
 
 
 @Data
-@Builder
+@Builder @NoArgsConstructor
+@AllArgsConstructor
 public class DailyTodoSaveRequestDto {
     // 투두 공통 속성
     @NotNull

--- a/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoModifyRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoModifyRequestDto.java
@@ -1,9 +1,10 @@
 package com.todoay.api.domain.todo.dto;
 
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
-import com.todoay.api.domain.todo.entity.Importance;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -11,13 +12,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Builder
+@Builder @NoArgsConstructor @AllArgsConstructor
 public class DueDateTodoModifyRequestDto {
     @NotNull
     private String title;
     private String description = "내용 없음";
-    private boolean isPublic = false;
-    private boolean isFinished = false;
+    private boolean publicBool = false;
+    private boolean finishedBool = false;
 
     // DuedateTodo 속성
     @NotNull

--- a/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoReadDetailResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoReadDetailResponseDto.java
@@ -1,0 +1,44 @@
+package com.todoay.api.domain.todo.dto;
+
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.todo.entity.DueDateTodo;
+import com.todoay.api.domain.todo.entity.Importance;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data @Builder
+public class DueDateTodoReadDetailResponseDto {
+
+    private Long id;
+    private String title;
+    private String description;
+    private boolean isPublic;
+    private boolean isFinished;
+
+    private List<HashtagInfoDto> hashtagInfoDtos = new ArrayList<>();
+    private LocalDate dueDate;
+    private Importance importance;
+
+    public static DueDateTodoReadDetailResponseDto createDto(DueDateTodo todo) {
+        return DueDateTodoReadDetailResponseDto.builder()
+                .title(todo.getTitle())
+                .id(todo.getId())
+                .description(todo.getDescription())
+                .isPublic(todo.isPublic())
+                .isFinished(todo.isFinished())
+                .dueDate(todo.getDueDate())
+                .importance(todo.getImportance())
+                .hashtagInfoDtos(todo.getTodoHashtags().stream()
+                        .map(todoHashtag ->
+                             new HashtagInfoDto(todoHashtag.getHashTag())
+                        ).collect(Collectors.toList())).build();
+    }
+
+}

--- a/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoReadResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoReadResponseDto.java
@@ -1,0 +1,34 @@
+package com.todoay.api.domain.todo.dto;
+
+import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import com.todoay.api.domain.todo.entity.DueDateTodo;
+import com.todoay.api.domain.todo.entity.Importance;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data @AllArgsConstructor @NoArgsConstructor
+public class DueDateTodoReadResponseDto {
+
+    Long id;
+    String title;
+    LocalDate dueDate;
+    Importance importance;
+    List<HashtagInfoDto> hashtagInfos = new ArrayList<>();
+
+    public static DueDateTodoReadResponseDto createDto(DueDateTodo todo) {
+       return  new DueDateTodoReadResponseDto(todo.getId(), todo.getTitle(), todo.getDueDate(),todo.getImportance()
+               ,todo.getTodoHashtags()
+               .stream()
+               .map(th -> new HashtagInfoDto(th.getHashTag())
+        ).collect(Collectors.toList()));
+    }
+
+
+
+}

--- a/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoSaveRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/DueDateTodoSaveRequestDto.java
@@ -1,9 +1,10 @@
 package com.todoay.api.domain.todo.dto;
 
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
-import com.todoay.api.domain.todo.entity.Importance;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -11,13 +12,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Builder
+@Builder @NoArgsConstructor @AllArgsConstructor
 public class DueDateTodoSaveRequestDto {
     // Todo 공통 속성
     @NotNull
     private String title;
     private String description = "내용 없음";
-    private boolean isPublic = false;
+    private boolean publicBool = false;
 
     // DuedateTodo 속성
     @NotNull

--- a/src/main/java/com/todoay/api/domain/todo/dto/OrderCondition.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/OrderCondition.java
@@ -1,0 +1,5 @@
+package com.todoay.api.domain.todo.dto;
+
+public enum OrderCondition {
+    DUEDATE,IMPORTANCE
+}

--- a/src/main/java/com/todoay/api/domain/todo/entity/DueDateTodo.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/DueDateTodo.java
@@ -1,18 +1,15 @@
 package com.todoay.api.domain.todo.entity;
 
 import com.todoay.api.domain.auth.entity.Auth;
-import com.todoay.api.domain.category.entity.Category;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -44,5 +41,18 @@ public class DueDateTodo extends Todo{
         this.description = description;
         this.importance = importance;
 
+    }
+
+    @Override
+    public String toString() {
+        return "DueDateTodo{" +
+                "dueDate=" + dueDate +
+                ", importance=" + importance +
+                ", id=" + id +
+                ", title='" + title + '\'' +
+                ", description='" + description + '\'' +
+                ", isPublic=" + isPublic +
+                ", isFinished=" + isFinished +
+                '}';
     }
 }

--- a/src/main/java/com/todoay/api/domain/todo/repository/DueDateTodoRepository.java
+++ b/src/main/java/com/todoay/api/domain/todo/repository/DueDateTodoRepository.java
@@ -1,7 +1,15 @@
 package com.todoay.api.domain.todo.repository;
 
+import com.todoay.api.domain.auth.entity.Auth;
 import com.todoay.api.domain.todo.entity.DueDateTodo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface DueDateTodoRepository extends JpaRepository<DueDateTodo, Long> {
+
+    @Query("select t from DueDateTodo t join fetch t.todoHashtags h where t.auth = :auth")
+    List<DueDateTodo> findAllByAuth(@Param("auth") Auth auth);
 }

--- a/src/main/java/com/todoay/api/domain/todo/repository/DueDateTodoRepository.java
+++ b/src/main/java/com/todoay/api/domain/todo/repository/DueDateTodoRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public interface DueDateTodoRepository extends JpaRepository<DueDateTodo, Long> {
 
-    @Query("select t from DueDateTodo t join fetch t.todoHashtags h where t.auth = :auth")
-    List<DueDateTodo> findAllByAuth(@Param("auth") Auth auth);
+    @Query("select distinct t from DueDateTodo t join fetch t.todoHashtags h where t.auth = :auth and t.isFinished = false")
+    List<DueDateTodo> findNotFinishedDueDateTodoByAuth(@Param("auth") Auth auth);
+    @Query("select distinct t from DueDateTodo t join fetch t.todoHashtags h where t.auth = :auth and t.isFinished = true ")
+    List<DueDateTodo> findFinishedDueDateTodoByAuth(@Param("auth")Auth auth);
 }

--- a/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDService.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDService.java
@@ -12,7 +12,7 @@ public interface DailyTodoCRUDService {
 
     List<DailyTodoReadResponseDto> readDailyTodosByDate(LocalDate date);
 
-    DailyTodoReadResponseDto readDailyTodoById(Long id);
+    DailyTodoReadDetailResponseDto readDailyTodoDetailById(Long id);
 
     // 반복 생성
     void repeatDailyTodo(Long id, DailyTodoRepeatRequestDto dto);

--- a/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
@@ -90,14 +90,14 @@ public class DailyTodoCRUDServiceImpl implements DailyTodoCRUDService{
         Auth loginedAuth = loginAuthContext.getLoginAuth();
         List<DailyTodo> dailyTodos = dailyTodoRepository.findDailyTodoOfUserByDate(date, loginedAuth);
         return dailyTodos.stream()
-                .map(DailyTodoReadResponseDto::createReadResponseDto)
+                .map(DailyTodoReadResponseDto::createDto)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public DailyTodoReadResponseDto readDailyTodoById(Long id) {
+    public DailyTodoReadDetailResponseDto readDailyTodoDetailById(Long id) {
         DailyTodo dailyTodo = checkIsPresentAndIsMineAndGetTodo(id);
-        return DailyTodoReadResponseDto.createReadResponseDto(dailyTodo);
+        return DailyTodoReadDetailResponseDto.createReadResponseDto(dailyTodo);
     }
 
     @Override

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDService.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDService.java
@@ -1,13 +1,20 @@
 package com.todoay.api.domain.todo.service;
 
 import com.todoay.api.domain.todo.dto.DueDateTodoModifyRequestDto;
+import com.todoay.api.domain.todo.dto.DueDateTodoReadResponseDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoSaveRequestDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoSaveResponseDto;
+
+import java.util.List;
 
 
 public interface DueDateTodoCRUDService {
     DueDateTodoSaveResponseDto addTodo(DueDateTodoSaveRequestDto dto);
     void modifyDueDateTodo(Long id, DueDateTodoModifyRequestDto dto);
     void deleteDueDateTodo(Long id);
+
+    List<DueDateTodoReadResponseDto> readTodosOrderByDueDate();
+
+    List<DueDateTodoReadResponseDto> readTodosOrderByImportance();
 
 }

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDService.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDService.java
@@ -1,9 +1,6 @@
 package com.todoay.api.domain.todo.service;
 
-import com.todoay.api.domain.todo.dto.DueDateTodoModifyRequestDto;
-import com.todoay.api.domain.todo.dto.DueDateTodoReadResponseDto;
-import com.todoay.api.domain.todo.dto.DueDateTodoSaveRequestDto;
-import com.todoay.api.domain.todo.dto.DueDateTodoSaveResponseDto;
+import com.todoay.api.domain.todo.dto.*;
 
 import java.util.List;
 
@@ -12,9 +9,8 @@ public interface DueDateTodoCRUDService {
     DueDateTodoSaveResponseDto addTodo(DueDateTodoSaveRequestDto dto);
     void modifyDueDateTodo(Long id, DueDateTodoModifyRequestDto dto);
     void deleteDueDateTodo(Long id);
+    List<DueDateTodoReadResponseDto> readTodosOrderByCondition(String condition);
 
-    List<DueDateTodoReadResponseDto> readTodosOrderByDueDate();
-
-    List<DueDateTodoReadResponseDto> readTodosOrderByImportance();
+    DueDateTodoReadDetailResponseDto readDueDateTodoDetail(Long id);
 
 }

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDService.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDService.java
@@ -13,4 +13,6 @@ public interface DueDateTodoCRUDService {
 
     DueDateTodoReadDetailResponseDto readDueDateTodoDetail(Long id);
 
+    List<DueDateTodoReadResponseDto> readFinishedTodos();
+
 }

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
@@ -74,10 +74,7 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
     public List<DueDateTodoReadResponseDto> readTodosOrderByCondition(String condition) {
         Auth loginedAuth = loginAuthContext.getLoginAuth();
         List<DueDateTodo> todos = dueDateTodoRepository.findNotFinishedDueDateTodoByAuth(loginedAuth);
-        log.info("origin todos = {}", todos);
-        List<DueDateTodoReadResponseDto> dtos = sortDueDateTodoByCondition(condition, todos);
-        log.info("dtos = {}", dtos);
-        return dtos;
+        return sortDueDateTodoByCondition(condition, todos);
     }
 
     @Override
@@ -90,10 +87,7 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
     public List<DueDateTodoReadResponseDto> readFinishedTodos() {
         Auth loginAuth = loginAuthContext.getLoginAuth();
         List<DueDateTodo> finishedTodos = dueDateTodoRepository.findFinishedDueDateTodoByAuth(loginAuth);
-        log.info("origin todos = {}", finishedTodos);
-        List<DueDateTodoReadResponseDto> dtos = sortTodosOrderByDueDate(finishedTodos);
-        log.info("dtos = {}", dtos);
-        return dtos;
+        return sortTodosOrderByDueDate(finishedTodos);
     }
 
     private List<DueDateTodoReadResponseDto> sortDueDateTodoByCondition(String condition, List<DueDateTodo> todos) {

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
@@ -4,6 +4,7 @@ import com.todoay.api.domain.auth.entity.Auth;
 import com.todoay.api.domain.auth.repository.AuthRepository;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
 import com.todoay.api.domain.todo.dto.DueDateTodoModifyRequestDto;
+import com.todoay.api.domain.todo.dto.DueDateTodoReadResponseDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoSaveRequestDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoSaveResponseDto;
 import com.todoay.api.domain.todo.entity.DueDateTodo;
@@ -19,6 +20,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -64,6 +68,20 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
         dueDateTodoRepository.delete(dueDateTodo);
     }
 
+    @Override
+    public List<DueDateTodoReadResponseDto> readTodosOrderByDueDate() {
+        Auth loginedAuth = loginAuthContext.getLoginAuth();
+        List<DueDateTodo> todos = dueDateTodoRepository.findAllByAuth(loginedAuth);
+        return sortDueDateTodoByDueDate(todos);
+    }
+
+    @Override
+    public List<DueDateTodoReadResponseDto> readTodosOrderByImportance() {
+        Auth loginedAuth = loginAuthContext.getLoginAuth();
+        List<DueDateTodo> todos = dueDateTodoRepository.findAllByAuth(loginedAuth);
+        return sortDueDateTodoByImportance(todos);
+    }
+
     private DueDateTodo checkIsPresentAndIsMineAndGetTodo(Long id) {
         DueDateTodo dueDateTodo = checkIsPresentAndGetTodo(id);
         checkThisTodoIsMine(dueDateTodo);
@@ -76,5 +94,19 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
 
     private DueDateTodo checkIsPresentAndGetTodo(Long id) {
         return dueDateTodoRepository.findById(id).orElseThrow(TodoNotFoundException::new);
+    }
+
+    private List<DueDateTodoReadResponseDto> sortDueDateTodoByDueDate(List<DueDateTodo> todos) {
+        return todos.stream()
+                .sorted(Comparator.comparing(DueDateTodo::getDueDate))
+                .map(DueDateTodoReadResponseDto::createDto)
+                .collect(Collectors.toList());
+    }
+
+    private List<DueDateTodoReadResponseDto> sortDueDateTodoByImportance(List<DueDateTodo> todos){
+        return todos.stream()
+                .sorted(Comparator.comparing(DueDateTodo::getImportance))
+                .map(DueDateTodoReadResponseDto::createDto)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/todoay/api/domain/todo/utility/EnumTransformer.java
+++ b/src/main/java/com/todoay/api/domain/todo/utility/EnumTransformer.java
@@ -9,6 +9,5 @@ public interface EnumTransformer {
         } catch (IllegalArgumentException e) {
             throw new EnumMismatchException();
         }
-
     }
 }

--- a/src/test/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImplTest.java
@@ -7,6 +7,7 @@ import com.todoay.api.domain.category.repository.CategoryRepository;
 import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
 import com.todoay.api.domain.todo.dto.DailyTodoDailyDateModifyRequestDto;
+import com.todoay.api.domain.todo.dto.DailyTodoReadDetailResponseDto;
 import com.todoay.api.domain.todo.dto.DailyTodoReadResponseDto;
 import com.todoay.api.domain.todo.dto.DailyTodoRepeatRequestDto;
 import com.todoay.api.domain.todo.entity.DailyTodo;
@@ -96,7 +97,7 @@ class DailyTodoCRUDServiceImplTest {
     @Test
     void readDailyDateById() {
 
-        DailyTodoReadResponseDto dto = dailyTodoCRUDService.readDailyTodoById(id);
+        DailyTodoReadDetailResponseDto dto = dailyTodoCRUDService.readDailyTodoDetailById(id);
         System.out.println(dto);
         assertThat(dto.getTitle()).isEqualTo("title");
     }
@@ -121,7 +122,7 @@ class DailyTodoCRUDServiceImplTest {
         DailyTodoDailyDateModifyRequestDto dto = new DailyTodoDailyDateModifyRequestDto();
         dto.setDailyDate(LocalDate.now());
         dailyTodoCRUDService.modifyDailyDate(id, dto);
-        DailyTodoReadResponseDto responseDto = dailyTodoCRUDService.readDailyTodoById(id);
+        DailyTodoReadDetailResponseDto responseDto = dailyTodoCRUDService.readDailyTodoDetailById(id);
         assertThat(responseDto.getDailyDate()).isEqualTo(LocalDate.now());
     }
     

--- a/src/test/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImplTest.java
@@ -1,9 +1,12 @@
 package com.todoay.api.domain.todo.service;
 
 import com.todoay.api.domain.auth.entity.Auth;
+import com.todoay.api.domain.todo.dto.DueDateTodoReadDetailResponseDto;
 import com.todoay.api.domain.todo.dto.DueDateTodoReadResponseDto;
 import com.todoay.api.domain.todo.entity.DueDateTodo;
 import com.todoay.api.domain.todo.entity.Importance;
+import com.todoay.api.domain.todo.exception.EnumMismatchException;
+import com.todoay.api.domain.todo.exception.TodoNotFoundException;
 import com.todoay.api.domain.todo.repository.DueDateTodoRepository;
 import com.todoay.api.global.context.LoginAuthContext;
 import org.assertj.core.api.SoftAssertions;
@@ -15,13 +18,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -30,47 +34,142 @@ class DueDateTodoCRUDServiceImplTest {
 
     @Mock
     DueDateTodoRepository dueDateTodoRepository;
-
-
-
     @Mock
     LoginAuthContext loginAuthContext;
     @InjectMocks
     DueDateTodoCRUDServiceImpl service;
 
     @Test
-    void readDueDateTodoOrderByDuedate() throws Exception {
-        // given
-        setMockObjectMethod();
-        // when
-        List<DueDateTodoReadResponseDto> dtos = service.readTodosOrderByDueDate();
+    void readDueDateTodoByCondition_Order() throws Exception{
+        //given
+        setMockObjectMethodForReadMultiObj();
 
-        // then
-        boolean equalResult = dtos.get(0).getDueDate().isEqual(dtos.get(1).getDueDate());
-        boolean beforeResult = dtos.get(0).getDueDate().isBefore(dtos.get(1).getDueDate());
-        boolean result = equalResult || beforeResult;
+        //when
+        String condition = "duedate";
+        List<DueDateTodoReadResponseDto> dtos = service.readTodosOrderByCondition(condition);
 
-        assertThat(result).isTrue();
+
+        //then
+        SoftAssertions.assertSoftly(sa -> {
+            for (int i = 0; i < dtos.size()-1; i++) {
+                sa.assertThat(compareDueDate(dtos.get(i),dtos.get(i+1))).isTrue();
+            }
+        });
     }
 
     @Test
-    void readDueDateTodoOrderByImportance() throws Exception {
+    void readDueDateTodoByCondition_Importance() throws Exception{
         //given
-        setMockObjectMethod();
+        setMockObjectMethodForReadMultiObj();
+
         //when
-        List<DueDateTodoReadResponseDto> todos = service.readTodosOrderByImportance();
+        String condition = "importance";
+        List<DueDateTodoReadResponseDto> dtos = service.readTodosOrderByCondition(condition);
+
 
         //then
         SoftAssertions.assertSoftly(softAssertions-> {
-            softAssertions.assertThat(todos.get(0).getImportance()).isEqualTo(Importance.HIGH);
-            softAssertions.assertThat(todos.get(1).getImportance()).isEqualTo(Importance.MIDDLE);
-            softAssertions.assertThat(todos.get(2).getImportance()).isEqualTo(Importance.LOW);
-            softAssertions.assertThat(todos.get(3).getImportance()).isEqualTo(Importance.LOW);
+            softAssertions.assertThat(dtos.get(0).getImportance()).isEqualTo(Importance.HIGH);
+            softAssertions.assertThat(dtos.get(1).getImportance()).isEqualTo(Importance.MIDDLE);
+            softAssertions.assertThat(dtos.get(2).getImportance()).isEqualTo(Importance.LOW);
+            softAssertions.assertThat(dtos.get(3).getImportance()).isEqualTo(Importance.LOW);
         });
-
     }
 
-    private void setMockObjectMethod() throws Exception {
+    @Test
+    void readDueDateTodoByCondition_Else() throws Exception{
+        //given
+        setMockObjectMethodForReadMultiObj();
+
+        //when
+        //then
+        String condition = "difficult";
+        assertThatThrownBy(() -> service.readTodosOrderByCondition(condition))
+               .isInstanceOf(EnumMismatchException.class);
+    }
+
+    @Test
+    void sortDueDateTodoOrderByDuedate() throws Exception {
+        // given
+        setMockObjectMethodForReadMultiObj();
+        Auth loginAuth = loginAuthContext.getLoginAuth();
+        List<DueDateTodo> todos = dueDateTodoRepository.findAllByAuth(loginAuth);
+        Method sortTodosOrderByDueDate = service.getClass().getDeclaredMethod("sortTodosOrderByDueDate",List.class);
+        sortTodosOrderByDueDate.setAccessible(true);
+
+        // when
+        List<DueDateTodoReadResponseDto> dtos = (List<DueDateTodoReadResponseDto>) sortTodosOrderByDueDate.invoke(service, todos);
+
+        // then
+        SoftAssertions.assertSoftly(sa -> {
+            for (int i = 0; i < dtos.size()-1; i++) {
+                sa.assertThat(compareDueDate(dtos.get(i),dtos.get(i+1))).isTrue();
+            }
+        });
+    }
+
+    private boolean compareDueDate(DueDateTodoReadResponseDto prev, DueDateTodoReadResponseDto next) {
+        boolean equalResult = prev.getDueDate().isEqual(next.getDueDate());
+        boolean beforeResult = prev.getDueDate().isBefore(next.getDueDate());
+        boolean result = equalResult || beforeResult;
+        return result;
+    }
+
+    @Test
+    void sortDueDateTodoOrderByImportance() throws Exception {
+        //given
+        setMockObjectMethodForReadMultiObj();
+        Auth loginAuth = loginAuthContext.getLoginAuth();
+        List<DueDateTodo> todos = dueDateTodoRepository.findAllByAuth(loginAuth);
+        Method sortTodosOrderByImportance = service.getClass().getDeclaredMethod("sortTodosOrderByImportance",List.class);
+        sortTodosOrderByImportance.setAccessible(true);
+        //when
+        List<DueDateTodoReadResponseDto> dtos = (List<DueDateTodoReadResponseDto>) sortTodosOrderByImportance.invoke(service, todos);
+
+        //then
+        SoftAssertions.assertSoftly(softAssertions-> {
+            softAssertions.assertThat(dtos.get(0).getImportance()).isEqualTo(Importance.HIGH);
+            softAssertions.assertThat(dtos.get(1).getImportance()).isEqualTo(Importance.MIDDLE);
+            softAssertions.assertThat(dtos.get(2).getImportance()).isEqualTo(Importance.LOW);
+            softAssertions.assertThat(dtos.get(3).getImportance()).isEqualTo(Importance.LOW);
+        });
+    }
+
+
+
+    @Test
+    void readDueDateDetail() throws Exception{
+        // given
+        setMockObjectMethodForDetailObj();
+        Long id = 1L;
+
+        // when
+        DueDateTodoReadDetailResponseDto detail = service.readDueDateTodoDetail(id);
+
+        // then
+        assertThat(detail.getId()).isSameAs(1L);
+    }
+
+    @Test
+    void readDueDateDetail_TodoNotFoundException () throws Exception{
+        //given
+        Long id = 1L;
+        //when
+        //then
+        assertThatThrownBy(() -> service.readDueDateTodoDetail(id))
+                .isInstanceOf(TodoNotFoundException.class);
+    }
+
+    private void setMockObjectMethodForDetailObj() throws Exception {
+        given(dueDateTodoRepository.findById(any()))
+                .willReturn(Optional.ofNullable(createDueDateTodoData().get(0)));
+        given(loginAuthContext.getLoginAuth())
+                .willReturn(createAuthData());
+    }
+
+
+
+    private void setMockObjectMethodForReadMultiObj() throws Exception {
         given(dueDateTodoRepository.findAllByAuth(any()))
                 .willReturn(createDueDateTodoData());
         given(loginAuthContext.getLoginAuth())
@@ -90,6 +189,7 @@ class DueDateTodoCRUDServiceImplTest {
     }
     private List<DueDateTodo> createDueDateTodoData() throws Exception{
         List<DueDateTodo> list = new ArrayList<>();
+        Auth auth = createAuthData();
         for (int i = 1; i < 5; i++) {
             DueDateTodo.DueDateTodoBuilder builder = DueDateTodo.builder()
                     .auth(null)
@@ -97,8 +197,8 @@ class DueDateTodoCRUDServiceImplTest {
                     .title("테스트" + i)
                     .description("테스트입니당" + i)
                     .isPublic(true)
+                    .auth(auth)
                     .isFinished(false);
-
 
             if(i<3)
                 builder.importance(Importance.LOW);

--- a/src/test/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImplTest.java
@@ -1,0 +1,120 @@
+package com.todoay.api.domain.todo.service;
+
+import com.todoay.api.domain.auth.entity.Auth;
+import com.todoay.api.domain.todo.dto.DueDateTodoReadResponseDto;
+import com.todoay.api.domain.todo.entity.DueDateTodo;
+import com.todoay.api.domain.todo.entity.Importance;
+import com.todoay.api.domain.todo.repository.DueDateTodoRepository;
+import com.todoay.api.global.context.LoginAuthContext;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DueDateTodoCRUDServiceImplTest {
+
+    @Mock
+    DueDateTodoRepository dueDateTodoRepository;
+
+
+
+    @Mock
+    LoginAuthContext loginAuthContext;
+    @InjectMocks
+    DueDateTodoCRUDServiceImpl service;
+
+    @Test
+    void readDueDateTodoOrderByDuedate() throws Exception {
+        // given
+        setMockObjectMethod();
+        // when
+        List<DueDateTodoReadResponseDto> dtos = service.readTodosOrderByDueDate();
+
+        // then
+        boolean equalResult = dtos.get(0).getDueDate().isEqual(dtos.get(1).getDueDate());
+        boolean beforeResult = dtos.get(0).getDueDate().isBefore(dtos.get(1).getDueDate());
+        boolean result = equalResult || beforeResult;
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void readDueDateTodoOrderByImportance() throws Exception {
+        //given
+        setMockObjectMethod();
+        //when
+        List<DueDateTodoReadResponseDto> todos = service.readTodosOrderByImportance();
+
+        //then
+        SoftAssertions.assertSoftly(softAssertions-> {
+            softAssertions.assertThat(todos.get(0).getImportance()).isEqualTo(Importance.HIGH);
+            softAssertions.assertThat(todos.get(1).getImportance()).isEqualTo(Importance.MIDDLE);
+            softAssertions.assertThat(todos.get(2).getImportance()).isEqualTo(Importance.LOW);
+            softAssertions.assertThat(todos.get(3).getImportance()).isEqualTo(Importance.LOW);
+        });
+
+    }
+
+    private void setMockObjectMethod() throws Exception {
+        given(dueDateTodoRepository.findAllByAuth(any()))
+                .willReturn(createDueDateTodoData());
+        given(loginAuthContext.getLoginAuth())
+                .willReturn(createAuthData());
+    }
+
+    private Auth createAuthData() throws Exception {
+        String password = new BCryptPasswordEncoder().encode("qwer1234!");
+        Auth auth = Auth.builder()
+                .email("test@naver.com")
+                .password(password)
+                .build();
+        Field id = auth.getClass().getDeclaredField("id");
+        id.setAccessible(true);
+        id.set(auth,1L);
+        return auth;
+    }
+    private List<DueDateTodo> createDueDateTodoData() throws Exception{
+        List<DueDateTodo> list = new ArrayList<>();
+        for (int i = 1; i < 5; i++) {
+            DueDateTodo.DueDateTodoBuilder builder = DueDateTodo.builder()
+                    .auth(null)
+                    .dueDate(LocalDate.of(2022, 8, i))
+                    .title("테스트" + i)
+                    .description("테스트입니당" + i)
+                    .isPublic(true)
+                    .isFinished(false);
+
+
+            if(i<3)
+                builder.importance(Importance.LOW);
+            else if(i==3)
+                builder.importance(Importance.MIDDLE);
+            else
+                builder.importance(Importance.HIGH);
+
+            DueDateTodo todo = builder.build();
+
+
+            Field id = todo.getClass().getSuperclass().getDeclaredField("id");
+            id.setAccessible(true);
+            id.set(todo,Integer.toUnsignedLong(i));
+            list.add(todo);
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
#147 관련 PR
### 기능 추가
### 1. Due-Date Todo 마감일 기준 조회
**> API : [GET] /todo/due-date/my?order=duedate**

**결과**

![마감일 기준 정렬](https://user-images.githubusercontent.com/76154390/186121748-810b65bd-9133-4374-96f1-56fbf0150281.png)

### 2. Due-Date Todo 중요도 기준 조회
**> API : [GET] /todo/due-date/my?order=importance**

**결과**
![중요도 기준 정렬](https://user-images.githubusercontent.com/76154390/186122027-3edd4065-7a15-44d8-8c36-9f7f79ab2ff1.png)

**1번과 2번은 같은 URL이지만  queryString으로 분기해서 적용**

### 3. Due-Date Todo ID로 상세조회
**> API : [GET] /todo/due-date/my/{id}**

**결과**
![Due-Date-Todo 상세조회](https://user-images.githubusercontent.com/76154390/186122261-7217c402-a821-402a-8229-67d593c1bd3f.png)

___

### 기능변경

### 1. Daily-Todo 리스트 조회와 ID를 통한 상세 조회의 리턴 값 변경

**리스트 조회**
![Daily-Todo 리스트조회](https://user-images.githubusercontent.com/76154390/186122665-14b241e6-36c5-4d7f-9ad6-87bd5856bff2.png)

**상세 조회**
![Daily-Todo 상세조회](https://user-images.githubusercontent.com/76154390/186122712-d57a68aa-5771-4ac0-8ec0-177f4a4fa717.png)

