### PR TITLE
해시태그 검색 조건 변경

### DIFF
--- a/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/controller/HashtagController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 @Validated
 @RequiredArgsConstructor
@@ -54,8 +53,9 @@ public class HashtagController {
             }
     )
     @GetMapping
-    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") @NotBlank String name, @RequestParam("pageNum") @Min(0) int pageNum) {
-        HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, pageNum);
+    public ResponseEntity<HashtagSearchResponseDto> searchHashtag(@RequestParam("name") @NotBlank String name
+            , @RequestParam("pageNum") @Min(0) int pageNum, @RequestParam("quantity") int quantity) {
+        HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, pageNum, quantity);
         return ResponseEntity.ok(dto);
     }
 

--- a/src/main/java/com/todoay/api/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/repository/HashtagRepository.java
@@ -17,5 +17,5 @@ public interface HashtagRepository extends JpaRepository<Hashtag,Long> {
     List<Hashtag> findTop5ByNameStartsWith(String name);
 
     // 페이지로 검색하기
-    Slice<Hashtag> findHashtagByNameStartsWith(String name, Pageable pageable);
+    Slice<Hashtag> findHashtagByNameContaining(String name, Pageable pageable);
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagService.java
@@ -11,7 +11,7 @@ public interface HashtagService {
 
     // 페이지로 검색하기
 
-    HashtagSearchResponseDto searchHashtag(String name, int pageNum);
+    HashtagSearchResponseDto searchHashtag(String name, int pageNum, int quantity);
 
 
 }

--- a/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/hashtag/service/HashtagServiceImpl.java
@@ -7,7 +7,6 @@ import com.todoay.api.domain.hashtag.dto.HashtagSearchResponseDto;
 import com.todoay.api.domain.hashtag.entity.Hashtag;
 import com.todoay.api.domain.hashtag.exception.NoMoreDataException;
 import com.todoay.api.domain.hashtag.repository.HashtagRepository;
-import com.todoay.api.domain.todo.entity.DailyTodo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -15,7 +14,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 @Slf4j
@@ -37,10 +35,10 @@ public class HashtagServiceImpl implements HashtagService{
     }
 
     @Override
-    public HashtagSearchResponseDto searchHashtag(String name, int pageNum) {
-        PageRequest pageRequest = PageRequest.of(pageNum, 5);
+    public HashtagSearchResponseDto searchHashtag(String name, int pageNum, int quantity) {
+        PageRequest pageRequest = PageRequest.of(pageNum, quantity);
 
-        Slice<Hashtag> page = hashtagRepository.findHashtagByNameStartsWith(name, pageRequest);
+        Slice<Hashtag> page = hashtagRepository.findHashtagByNameContaining(name, pageRequest);
         List<HashtagInfoDto> infoDtos = page.getContent().stream()
                 .map(HashtagInfoDto::new)
                 .collect(Collectors.toList());

--- a/src/test/java/com/todoay/api/domain/hashtag/repository/HashtagRepositoryTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/repository/HashtagRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.todoay.api.domain.hashtag.repository;
 
 import com.todoay.api.domain.hashtag.entity.Hashtag;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,6 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class HashtagRepositoryTest {
@@ -48,7 +46,7 @@ class HashtagRepositoryTest {
         PageRequest request = PageRequest.of(0,5);
         String name = "#tag";
 
-        Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
+        Slice<Hashtag> tags = repository.findHashtagByNameContaining(name, request);
         List<Hashtag> content = tags.getContent();
 
         assertThat(tags.hasNext()).isTrue();
@@ -62,7 +60,7 @@ class HashtagRepositoryTest {
         PageRequest request = PageRequest.of(1,5);
         String name = "#tag";
 
-        Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
+        Slice<Hashtag> tags = repository.findHashtagByNameContaining(name, request);
         List<Hashtag> content = tags.getContent();
 
         assertThat(tags.hasNext()).isTrue();
@@ -75,7 +73,7 @@ class HashtagRepositoryTest {
         PageRequest request = PageRequest.of(10,5);
         String name = "#tag";
 
-        Slice<Hashtag> tags = repository.findHashtagByNameStartsWith(name, request);
+        Slice<Hashtag> tags = repository.findHashtagByNameContaining(name, request);
         List<Hashtag> content = tags.getContent();
         assertThat(tags.hasNext()).isFalse();
         assertThat(tags.getNumber()).isNotSameAs(1);

--- a/src/test/java/com/todoay/api/domain/hashtag/service/HashtagServiceImplTest.java
+++ b/src/test/java/com/todoay/api/domain/hashtag/service/HashtagServiceImplTest.java
@@ -53,7 +53,7 @@ class HashtagServiceImplTest {
     @Test
     void search_test() {
 
-        HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, 0);
+        HashtagSearchResponseDto dto = hashtagService.searchHashtag(name, 0, 5);
         List<HashtagInfoDto> infos = dto.getInfos();
         int nextPage = dto.getNextPageNum();
         boolean hasNext = dto.isHasNext();
@@ -66,13 +66,13 @@ class HashtagServiceImplTest {
 
     @Test
     void search_test_exception_page() {
-        assertThatThrownBy(() -> hashtagService.searchHashtag(name, 1000))
+        assertThatThrownBy(() -> hashtagService.searchHashtag(name, 1000, 5))
                 .isInstanceOf(NoMoreDataException.class);
     }
 
     @Test
     void search_test_exception_name() {
-        assertThatThrownBy(() -> hashtagService.searchHashtag("qwecqwceqwecqwec", 0))
+        assertThatThrownBy(() -> hashtagService.searchHashtag("qwecqwceqwecqwec", 0, 5))
                 .isInstanceOf(NoMoreDataException.class);
     }
 


### PR DESCRIPTION
1. 해시태그를 검색할 때 Where 절 쿼리 변경 like name%(startWith) -> like %name%(containing)
2. 해시태그 반환 개수 param으로 받아서 검색

아래 사진을 보면 '그' 로 검색해도 태그가 전부 나오는걸 확인 가능, quantity를 8로 주어서 태그가 0부터 7까지 검색되는 것을 확인 가능
![image](https://user-images.githubusercontent.com/76154390/187577116-801f42fb-ef0a-4886-800f-d1af5ce5b835.png)
