### PR TITLE
S3 활용해서 이미지 업로드 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
@@ -50,9 +50,12 @@ public class ProfileController {
             description = "Jwt 토큰을 통해 얻은 email 얻은 정보를 dto로 받은 정보로 수정한다. 이때 JWT 토큰으로 인한 오류와 입력 값에 대한 유효성 검사로 인해 오류가 발생할 수 있다.",
             responses = {
                     @ApiResponse(responseCode = "204", description = "성공"),
-                    @ApiResponse(responseCode = "400", description = "입력 값이 유효성 검사를 통과하지 못했습니다.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "1. 입력 값이 유효성 검사를 통과하지 못했습니다.\t\n " +
+                            "2. 이미지 파일이 아닌 파일을 업로드 했습니다.\t\n " +
+                            "3. 파일 사이즈 초과", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
                     @ApiResponse(responseCode = "401", description = "AccessToken 만료 ",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "403",description = "허락되지 않은 접근",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "IO 리소스 문제 발생",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @PutMapping("/profile/my")

--- a/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/todoay/api/domain/profile/controller/ProfileController.java
@@ -5,7 +5,6 @@ import com.todoay.api.domain.profile.dto.ProfileUpdateReqeustDto;
 import com.todoay.api.domain.profile.service.ProfileService;
 import com.todoay.api.global.exception.ErrorResponse;
 import com.todoay.api.global.exception.ValidErrorResponse;
-import com.todoay.api.global.jwt.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,10 +15,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -58,8 +56,8 @@ public class ProfileController {
             }
     )
     @PutMapping("/profile/my")
-    public ResponseEntity<Void> updateProfile(@RequestBody @Validated ProfileUpdateReqeustDto dto) {
-        profileService.updateMyProfile(dto);
+    public ResponseEntity<Void> updateProfile(@RequestPart("image") MultipartFile multipartFile, @RequestPart("profile") @Validated ProfileUpdateReqeustDto dto) {
+        profileService.updateMyProfile(multipartFile,dto);
 
         return ResponseEntity.status(204).build();
     }

--- a/src/main/java/com/todoay/api/domain/profile/exception/FileTypeMismatchException.java
+++ b/src/main/java/com/todoay/api/domain/profile/exception/FileTypeMismatchException.java
@@ -1,0 +1,11 @@
+package com.todoay.api.domain.profile.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+
+import static com.todoay.api.domain.profile.exception.ProfileErrorCode.FILE_TYPE_MISMATCH;
+
+public class FileTypeMismatchException extends AbstractApiException {
+    public FileTypeMismatchException() {
+        super(FILE_TYPE_MISMATCH);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/profile/exception/FileUploadErrorException.java
+++ b/src/main/java/com/todoay/api/domain/profile/exception/FileUploadErrorException.java
@@ -1,0 +1,11 @@
+package com.todoay.api.domain.profile.exception;
+
+import com.todoay.api.global.exception.AbstractApiException;
+
+import static com.todoay.api.domain.profile.exception.ProfileErrorCode.FILE_UPLOAD_ERROR;
+
+public class FileUploadErrorException extends AbstractApiException {
+    public FileUploadErrorException() {
+        super(FILE_UPLOAD_ERROR);
+    }
+}

--- a/src/main/java/com/todoay/api/domain/profile/exception/ProfileErrorCode.java
+++ b/src/main/java/com/todoay/api/domain/profile/exception/ProfileErrorCode.java
@@ -11,7 +11,14 @@ import org.springframework.http.HttpStatus;
 public enum ProfileErrorCode implements ErrorCode {
 
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 이메일입니다."),
-    NICKNAME_DUPLICATE(HttpStatus.FORBIDDEN, "이미 사용 중인 닉네임입니다.");
+    NICKNAME_DUPLICATE(HttpStatus.FORBIDDEN, "이미 사용 중인 닉네임입니다."),
+
+    FILE_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "이미지 파일이 아닌 파일을 업로드 했습니다."),
+    
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "IO 리소스 문제 발생"),
+
+    SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 사이즈 초과")
+    ;
 
 
 

--- a/src/main/java/com/todoay/api/domain/profile/service/AmazonS3Service.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/AmazonS3Service.java
@@ -1,0 +1,9 @@
+package com.todoay.api.domain.profile.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AmazonS3Service {
+
+    // 업로드 기능
+    String uploadImage(MultipartFile multipartFile,String prevImgUrl);
+}

--- a/src/main/java/com/todoay/api/domain/profile/service/AmazonS3ServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/AmazonS3ServiceImpl.java
@@ -1,0 +1,91 @@
+package com.todoay.api.domain.profile.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class AmazonS3ServiceImpl implements AmazonS3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String uploadImage(MultipartFile multipartFile, String prevImgUrl) {
+        if(multipartFile.isEmpty())
+            return null;
+
+        try {
+
+            if (prevImgUrl != null) {
+                remove(prevImgUrl);
+            }
+            File file = convertMultipartFileToFile(multipartFile)
+                    .orElseThrow();
+
+            String imageUrl = upload(file);
+
+            removeFile(file);
+            return imageUrl;
+        } catch (IOException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    private Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+        File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
+
+        if (file.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(file)){
+                fos.write(multipartFile.getBytes());
+            }
+            return Optional.of(file);
+        }
+        return Optional.empty();
+    }
+
+    private String upload(File file) {
+        String dirName = createRandomName();
+        return putS3(file,dirName);
+    }
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return getS3(bucket, fileName);
+    }
+
+
+    private String getS3(String bucket, String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    public void remove(String prevImgUrl) {
+        int index = prevImgUrl.lastIndexOf("upload/");
+        String key = prevImgUrl.substring(index);
+
+        if (!amazonS3.doesObjectExist(bucket, key)) {
+            throw new AmazonS3Exception("Object " +key+ " does not exist!");
+        }
+        amazonS3.deleteObject(bucket, key);
+    }
+    private String createRandomName() {
+        return  "upload/" + UUID.randomUUID().toString();
+    }
+    private void removeFile(File file) {
+        file.delete();
+    }
+}

--- a/src/main/java/com/todoay/api/domain/profile/service/AmazonS3ServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/AmazonS3ServiceImpl.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.todoay.api.domain.profile.exception.FileTypeMismatchException;
+import com.todoay.api.domain.profile.exception.FileUploadErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,8 @@ public class AmazonS3ServiceImpl implements AmazonS3Service {
     public String uploadImage(MultipartFile multipartFile, String prevImgUrl) {
         if(multipartFile.isEmpty())
             return null;
+        if(!multipartFile.getContentType().contains("image"))
+            throw new FileTypeMismatchException();
 
         try {
 
@@ -42,7 +46,7 @@ public class AmazonS3ServiceImpl implements AmazonS3Service {
             removeFile(file);
             return imageUrl;
         } catch (IOException e) {
-            throw new RuntimeException();
+            throw new FileUploadErrorException();
         }
     }
 
@@ -73,7 +77,7 @@ public class AmazonS3ServiceImpl implements AmazonS3Service {
         return amazonS3.getUrl(bucket, fileName).toString();
     }
 
-    public void remove(String prevImgUrl) {
+    private void remove(String prevImgUrl) {
         int index = prevImgUrl.lastIndexOf("upload/");
         String key = prevImgUrl.substring(index);
 

--- a/src/main/java/com/todoay/api/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/ProfileService.java
@@ -2,6 +2,7 @@ package com.todoay.api.domain.profile.service;
 
 import com.todoay.api.domain.profile.dto.ProfileReadResponseDto;
 import com.todoay.api.domain.profile.dto.ProfileUpdateReqeustDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ProfileService {
 
@@ -11,7 +12,7 @@ public interface ProfileService {
     ProfileReadResponseDto readMyProfile();
 
     // 내 정보 변경
-    void updateMyProfile(ProfileUpdateReqeustDto dto);
+    void updateMyProfile(MultipartFile multipartFile, ProfileUpdateReqeustDto dto);
 
     boolean nicknameExists(String nickname);
 

--- a/src/main/java/com/todoay/api/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/profile/service/ProfileServiceImpl.java
@@ -10,6 +10,7 @@ import com.todoay.api.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor @Transactional(readOnly = true)
@@ -17,6 +18,8 @@ public class ProfileServiceImpl implements ProfileService {
 
     private final ProfileRepository profileRepository;
     private final JwtProvider jwtProvider;
+
+    private final AmazonS3Service amazonS3Service;
 
 
     @Override
@@ -30,7 +33,7 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Transactional
     @Override
-    public void updateMyProfile(ProfileUpdateReqeustDto dto) {
+    public void updateMyProfile(MultipartFile multipartFile, ProfileUpdateReqeustDto dto) {
         String email = jwtProvider.getLoginId();
         Profile profile = getProfileByEmailOrElseThrowEmailNotFoundException(email);
 
@@ -41,7 +44,11 @@ public class ProfileServiceImpl implements ProfileService {
                         throw new NicknameDuplicateException();
                     }
             );
+        String uploadImageUrl = amazonS3Service.uploadImage(multipartFile, dto.getImageUrl());
+        if(uploadImageUrl!=null)
+            dto.setImageUrl(uploadImageUrl);
         profile.updateProfile(dto);
+
     }
 
     @Override

--- a/src/main/java/com/todoay/api/global/config/GlobalBeanConfig.java
+++ b/src/main/java/com/todoay/api/global/config/GlobalBeanConfig.java
@@ -1,5 +1,10 @@
 package com.todoay.api.global.config;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -10,5 +15,27 @@ public class GlobalBeanConfig {
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public BasicAWSCredentials basicAWSCredentials() {
+        return new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(BasicAWSCredentials basicAWSCredentials) {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
     }
 }

--- a/src/main/java/com/todoay/api/global/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/todoay/api/global/config/GlobalExceptionHandler.java
@@ -3,28 +3,27 @@ package com.todoay.api.global.config;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.todoay.api.global.exception.AbstractApiException;
 import com.todoay.api.global.exception.ErrorResponse;
-import com.todoay.api.global.exception.GlobalErrorCode;
 import com.todoay.api.global.exception.ValidErrorResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.MethodParameter;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
-import java.lang.reflect.Method;
 import java.sql.SQLIntegrityConstraintViolationException;
 
+import static com.todoay.api.domain.profile.exception.ProfileErrorCode.SIZE_LIMIT_EXCEEDED;
 import static com.todoay.api.global.exception.GlobalErrorCode.*;
-import static com.todoay.api.global.exception.GlobalErrorCode.SQL_INTEGRITY_CONSTRAINT_VIOLATION;
 
 @Slf4j
 @RestControllerAdvice
@@ -83,6 +82,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(JsonParseException.class)
     public ResponseEntity<ErrorResponse> handleJsonParseException(HttpServletRequest request) {
         return ErrorResponse.toResponseEntity(JSON_PARSE_ERROR, request.getRequestURI());
+    }
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleSizeLimitExceededException(HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(SIZE_LIMIT_EXCEEDED, request.getRequestURI());
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(HttpServletRequest request) {
+        return ErrorResponse.toResponseEntity(MISSING_REQUEST_PART, request.getRequestURI());
     }
 
 }

--- a/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/todoay/api/global/exception/GlobalErrorCode.java
@@ -22,7 +22,9 @@ public enum GlobalErrorCode implements ErrorCode{
 
     REQUEST_PARAM_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "리퀘스트 파라미터의 타입이 올바르지 않습니다."),
 
-    JSON_PARSE_ERROR(HttpStatus.FORBIDDEN, "JSON을 파싱하는 과정에서 문제가 발생했습니다.")
+    JSON_PARSE_ERROR(HttpStatus.FORBIDDEN, "JSON을 파싱하는 과정에서 문제가 발생했습니다."),
+
+    MISSING_REQUEST_PART(HttpStatus.BAD_REQUEST, "전달해야 하는 RequestPart를 전달하지 않았습니다.")
 
 
     ;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   config:
-    import: classpath:mailSender.yml
+    import:
+      - classpath:mailSender.yml
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   config:
     import:
       - classpath:mailSender.yml
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
S3 활용해 이미지 업로드 기능 추가.

[PUT] /profile/my <- 내 프로필 수정 기능에서 MultiPartFile을 같이 전달하여 이미지를 업로드한다.
![image](https://user-images.githubusercontent.com/76154390/188455018-7057fb03-163f-46d4-9e90-57052d1e061b.png)

이미지 업로드가 성공하면 내 정보 조회에서 업로드된 이미지의 URL이 전송이 반환이 된다.
![image](https://user-images.githubusercontent.com/76154390/188455107-5591336e-74f4-46b2-ace6-fc8add32d835.png)

이미지 확인 가능
![image](https://user-images.githubusercontent.com/76154390/188455159-4a81b81c-1055-4095-a1b9-0cd8d87a0701.png)

DB에는 전체 URL을 저장하는 식으로 진행
![image](https://user-images.githubusercontent.com/76154390/188455257-65798a3c-cb33-4204-9d76-cd81fe41e045.png)
