### PR TITLE
Todo-Modify 기능에서 완료 관련 필드 삭제

### DIFF
--- a/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoModifyRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoModifyRequestDto.java
@@ -1,8 +1,10 @@
 package com.todoay.api.domain.todo.dto.daily;
 
 import com.todoay.api.domain.hashtag.dto.HashtagInfoDto;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -12,14 +14,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Builder
+@Builder @NoArgsConstructor @AllArgsConstructor
 public class DailyTodoModifyRequestDto {
     // 투두 공통 속성
     @NotBlank
     private String title;
     private String description = "내용 없음";
-    private boolean isPublic = false;
-    private boolean isFinished = false;
+    private boolean publicBool = false;
 
     // DailyTodo 속성
     private LocalDateTime alarm;

--- a/src/main/java/com/todoay/api/domain/todo/dto/duedate/DueDateTodoModifyRequestDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/duedate/DueDateTodoModifyRequestDto.java
@@ -19,7 +19,6 @@ public class DueDateTodoModifyRequestDto {
     private String title;
     private String description = "내용 없음";
     private boolean publicBool = false;
-    private boolean finishedBool = false;
 
     // DuedateTodo 속성
     @NotNull

--- a/src/main/java/com/todoay/api/domain/todo/entity/DailyTodo.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/DailyTodo.java
@@ -15,7 +15,6 @@ import javax.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 
 @Entity
 @Getter
@@ -54,8 +53,7 @@ public class DailyTodo extends Todo implements Cloneable{
     }
     public void modify(DailyTodoModifyRequestDto dto,Category category) {
         this.title = dto.getTitle();
-        this.isPublic = dto.isPublic();
-        this.isFinished = dto.isFinished();
+        this.isPublic = dto.isPublicBool();
         this.description = dto.getDescription();
         this.targetTime= dto.getTargetTime();
         this.alarm = dto.getAlarm();

--- a/src/main/java/com/todoay/api/domain/todo/entity/DueDateTodo.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/DueDateTodo.java
@@ -33,10 +33,9 @@ public class DueDateTodo extends Todo{
         this.auth = auth;
     }
 
-    public void modify(String title, boolean isPublic,boolean isFinished, LocalDate dueDate, String description, Importance importance) {
+    public void modify(String title, boolean isPublic, LocalDate dueDate, String description, Importance importance) {
         this.title = title;
         this.isPublic = isPublic;
-        this.isFinished = isFinished;
         this.dueDate = dueDate;
         this.description = description;
         this.importance = importance;

--- a/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DueDateTodoCRUDServiceImpl.java
@@ -56,7 +56,7 @@ public class DueDateTodoCRUDServiceImpl implements DueDateTodoCRUDService {
     @Transactional
     public void modifyDueDateTodo(Long id, DueDateTodoModifyRequestDto dto) {
         DueDateTodo dueDateTodo = checkIsPresentAndIsMineAndGetTodo(id);
-        dueDateTodo.modify(dto.getTitle(), dto.isPublicBool(),dto.isFinishedBool(), dto.getDueDate(), dto.getDescription(),
+        dueDateTodo.modify(dto.getTitle(), dto.isPublicBool(), dto.getDueDate(), dto.getDescription(),
                 (Importance) EnumTransformer.valueOfEnum(Importance.class,dto.getImportance()));
         HashtagAttacher.attachHashtag(dueDateTodo, dto.getHashtagNames(), hashtagRepository);
     }


### PR DESCRIPTION
#172

DailyTodoModifyRequestDto, DueDateTodoModifyReqeustDto에서 완료 관련 필드 삭제, Service 혹은 Entity에서 진행하는 modify의 파라미터에서도 관련 필드 삭제