### PR TITLE
FEAT : Daily Todo 반복 그룹 전체 삭제 기능 추가 #186

### DIFF
--- a/src/main/java/com/todoay/api/domain/todo/controller/DailyTodoController.java
+++ b/src/main/java/com/todoay/api/domain/todo/controller/DailyTodoController.java
@@ -87,10 +87,24 @@ public class DailyTodoController {
                     @ApiResponse(responseCode = "403", description = "1. 내 TODO가 아닌 TODO에 접근 \t\n 2. ENUM 변환 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "해당 ID에 리소스가 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
-
     )
     public ListenableFuture<ResponseEntity<Void>> repeatDailyTodoByCondition(@PathVariable("id") long id, @RequestBody @Validated DailyTodoRepeatRequestDto dto) {
         return dailyTodoCRUDService.repeatDailyTodo(id, dto);
+    }
+    @DeleteMapping("/{id}/repeat")
+    @Operation(
+            summary = "로그인 유저의 반복 그룹에 엮이 Daily Todo를 전부 삭제한다",
+            responses = {
+                    @ApiResponse(responseCode = "204"),
+                    @ApiResponse(responseCode = "400", description = "올바른 양식을 입력하지 않음.", content = @Content(schema = @Schema(implementation = ValidErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Access Token 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "리소스가 로그인 유저의 것이 아님", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 id의 리소스가 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    public ResponseEntity<Void> deleteAllRepeatGroupById(@PathVariable("id") long id) {
+        dailyTodoCRUDService.deleteAllRepeatedDailyTodo(id);
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoReadDetailResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoReadDetailResponseDto.java
@@ -32,6 +32,8 @@ public class DailyTodoReadDetailResponseDto {
     private LocalDate dailyDate;
     private CategoryInfoDto category;
 
+    private Long repeatId;
+
     private List<HashtagInfoDto> hashtagNames = new ArrayList<>();
 
     public static DailyTodoReadDetailResponseDto createReadResponseDto(DailyTodo dailyTodo) {
@@ -57,6 +59,8 @@ public class DailyTodoReadDetailResponseDto {
         if (isStrNotNull(dailyTodo.getPlace()))
             dto.place = dailyTodo.getPlace();
         dto.dailyDate = dailyTodo.getDailyDate();
+        if(dailyTodo.getRepeatGroup() != null)
+            dto.repeatId = dailyTodo.getRepeatGroup().getId();
         return dto;
     }
 

--- a/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoReadResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoReadResponseDto.java
@@ -11,7 +11,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Data @NoArgsConstructor @AllArgsConstructor @Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class DailyTodoReadResponseDto {
 
     private Long id;
@@ -25,17 +28,20 @@ public class DailyTodoReadResponseDto {
 
     public static DailyTodoReadResponseDto createDto(DailyTodo todo) {
 
-        return DailyTodoReadResponseDto.builder()
+        DailyTodoReadResponseDtoBuilder builder = DailyTodoReadResponseDto.builder()
                 .id(todo.getId())
                 .title(todo.getTitle())
                 .isPublic(todo.isPublic())
                 .isFinished(todo.isFinished())
                 .categoryId(todo.getCategory().getId())
-                .repeatId(todo.getRepeatGroup().getId())
                 .hashtagInfoDtos(todo.getTodoHashtags().stream()
-                        .map(th-> new HashtagInfoDto(th.getHashTag()))
-                        .collect(Collectors.toList()))
-                .build();
+                        .map(th -> new HashtagInfoDto(th.getHashTag()))
+                        .collect(Collectors.toList()));
+
+        if(todo.getRepeatGroup() != null)
+            builder.repeatId(todo.getRepeatGroup().getId());
+
+        return builder.build();
 
     }
 

--- a/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoReadResponseDto.java
+++ b/src/main/java/com/todoay/api/domain/todo/dto/daily/DailyTodoReadResponseDto.java
@@ -20,6 +20,7 @@ public class DailyTodoReadResponseDto {
     private boolean isFinished;
 
     private Long categoryId;
+    private Long repeatId;
     private List<HashtagInfoDto> hashtagInfoDtos = new ArrayList<>();
 
     public static DailyTodoReadResponseDto createDto(DailyTodo todo) {
@@ -30,6 +31,7 @@ public class DailyTodoReadResponseDto {
                 .isPublic(todo.isPublic())
                 .isFinished(todo.isFinished())
                 .categoryId(todo.getCategory().getId())
+                .repeatId(todo.getRepeatGroup().getId())
                 .hashtagInfoDtos(todo.getTodoHashtags().stream()
                         .map(th-> new HashtagInfoDto(th.getHashTag()))
                         .collect(Collectors.toList()))

--- a/src/main/java/com/todoay/api/domain/todo/entity/DailyTodo.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/DailyTodo.java
@@ -34,6 +34,10 @@ public class DailyTodo extends Todo implements Cloneable{
     @JoinColumn(name = "category_id")
     private Category category;
 
+    @ManyToOne
+    @JoinColumn(name = "repeat_id")
+    private RepeatGroup repeatGroup;
+
 
     @Builder
     public DailyTodo(String title, boolean isPublic, boolean isFinished, String description,LocalDateTime targetTime,LocalDateTime alarm, String place, String people, LocalDate dailyDate, Category category, Auth auth) {
@@ -111,6 +115,10 @@ public class DailyTodo extends Todo implements Cloneable{
         if (this.targetTime != null) {
             this.targetTime = LocalDateTime.of(dailyDate, LocalTime.of(this.targetTime.getHour(),targetTime.getMinute()));
         }
+    }
+    public void enterRepeatGroup(RepeatGroup repeatGroup) {
+        this.repeatGroup = repeatGroup;
+        this.repeatGroup.getDailyTodos().add(this);
     }
 
 }

--- a/src/main/java/com/todoay/api/domain/todo/entity/RepeatGroup.java
+++ b/src/main/java/com/todoay/api/domain/todo/entity/RepeatGroup.java
@@ -1,0 +1,21 @@
+package com.todoay.api.domain.todo.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity @Getter @NoArgsConstructor
+public class RepeatGroup {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @OneToMany(mappedBy = "repeatGroup", orphanRemoval = true)
+    private List<DailyTodo> dailyTodos = new ArrayList<>();
+}

--- a/src/main/java/com/todoay/api/domain/todo/repository/DailyTodoRepository.java
+++ b/src/main/java/com/todoay/api/domain/todo/repository/DailyTodoRepository.java
@@ -18,6 +18,7 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
             "join fetch t.auth a " +
             "join fetch t.category c " +
             "join fetch a.profile p " +
+            "join fetch t.repeatGroup r " +
             "where t.dailyDate =:localDate " +
             "and t.auth =:auth")
     List<DailyTodo> findDailyTodoOfUserByDate(@Param("localDate") LocalDate localDate, @Param("auth") Auth auth);

--- a/src/main/java/com/todoay/api/domain/todo/repository/DailyTodoRepository.java
+++ b/src/main/java/com/todoay/api/domain/todo/repository/DailyTodoRepository.java
@@ -18,7 +18,7 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
             "join fetch t.auth a " +
             "join fetch t.category c " +
             "join fetch a.profile p " +
-            "join fetch t.repeatGroup r " +
+            "left join fetch t.repeatGroup r " +
             "where t.dailyDate =:localDate " +
             "and t.auth =:auth")
     List<DailyTodo> findDailyTodoOfUserByDate(@Param("localDate") LocalDate localDate, @Param("auth") Auth auth);
@@ -29,6 +29,7 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
             "join fetch t.auth a " +
             "join fetch t.category c " +
             "join fetch a.profile p " +
+            "left join fetch t.repeatGroup r " +
             "where t.id =:id")
     Optional<DailyTodo> findDailyTodoById(@Param("id") Long id);
 }

--- a/src/main/java/com/todoay/api/domain/todo/repository/RepeatRepository.java
+++ b/src/main/java/com/todoay/api/domain/todo/repository/RepeatRepository.java
@@ -1,0 +1,7 @@
+package com.todoay.api.domain.todo.repository;
+
+import com.todoay.api.domain.todo.entity.RepeatGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepeatRepository extends JpaRepository<RepeatGroup, Long> {
+}

--- a/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDService.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDService.java
@@ -21,4 +21,6 @@ public interface DailyTodoCRUDService extends TodoValidator {
     ListenableFuture<ResponseEntity<Void>> repeatDailyTodo(Long id, DailyTodoRepeatRequestDto dto);
 
     void modifyDailyDate(Long id, DailyTodoDailyDateModifyRequestDto dto);
+
+    void deleteAllRepeatedDailyTodo(Long id);
 }

--- a/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
@@ -121,6 +121,7 @@ public class DailyTodoCRUDServiceImpl implements DailyTodoCRUDService{
         dailyTodo.changeDailyDate(dto.getDailyDate());
     }
 
+    @Transactional
     @Override
     public void deleteAllRepeatedDailyTodo(Long id) {
         DailyTodo dailyTodo = checkIsPresentAndIsMineAndGetTodo(id);

--- a/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
+++ b/src/main/java/com/todoay/api/domain/todo/service/DailyTodoCRUDServiceImpl.java
@@ -11,9 +11,11 @@ import com.todoay.api.domain.hashtag.repository.HashtagRepository;
 import com.todoay.api.domain.profile.exception.EmailNotFoundException;
 import com.todoay.api.domain.todo.dto.daily.*;
 import com.todoay.api.domain.todo.entity.DailyTodo;
+import com.todoay.api.domain.todo.entity.RepeatGroup;
 import com.todoay.api.domain.todo.entity.TodoHashtag;
 import com.todoay.api.domain.todo.exception.TodoNotFoundException;
 import com.todoay.api.domain.todo.repository.DailyTodoRepository;
+import com.todoay.api.domain.todo.repository.RepeatRepository;
 import com.todoay.api.domain.todo.utility.EnumTransformer;
 import com.todoay.api.domain.todo.utility.HashtagAttacher;
 import com.todoay.api.domain.todo.utility.repeat.Duration;
@@ -42,6 +44,8 @@ public class DailyTodoCRUDServiceImpl implements DailyTodoCRUDService{
     private final DailyTodoRepository dailyTodoRepository;
     private final CategoryRepository categoryRepository;
     private final AuthRepository authRepository;
+
+    private final RepeatRepository repeatRepository;
 
     private final HashtagRepository hashtagRepository;
     private final JwtProvider jwtProvider;
@@ -117,13 +121,23 @@ public class DailyTodoCRUDServiceImpl implements DailyTodoCRUDService{
         dailyTodo.changeDailyDate(dto.getDailyDate());
     }
 
+    @Override
+    public void deleteAllRepeatedDailyTodo(Long id) {
+        DailyTodo dailyTodo = checkIsPresentAndIsMineAndGetTodo(id);
+        repeatRepository.deleteById(dailyTodo.getRepeatGroup().getId());
+    }
+
     private void createDailyTodoByRepeatedDate(DailyTodo source, List<LocalDate> repeatedDate) {
+        RepeatGroup repeatGroup = new RepeatGroup();
+        repeatRepository.save(repeatGroup);
+        source.enterRepeatGroup(repeatGroup);
         repeatedDate.forEach(d ->{
             DailyTodo repeated = (DailyTodo) source.clone();
             repeated.changeDateForRepeat(d);
             List<Hashtag> hashtags = source.getTodoHashtags().stream().map(TodoHashtag::getHashTag)
                     .collect(Collectors.toList());
             repeated.associateWithHashtag(hashtags);
+            repeated.enterRepeatGroup(repeatGroup);
             dailyTodoRepository.save(repeated);
         });
     }


### PR DESCRIPTION
작업은 이슈 #186 참고

### 결과

---

#### 전체 조회 시 repeatID 전달

![image](https://user-images.githubusercontent.com/76154390/192446234-1fd6cc7b-e44b-4fbd-b418-2c2f32f6d91e.png)

#### Daily Todo Entity 클래스 변경

![image](https://user-images.githubusercontent.com/76154390/192446395-9b0d32d6-e352-403e-bb97-8043c29f0d91.png)

![image](https://user-images.githubusercontent.com/76154390/192446407-4fed5466-351a-4a18-9d8e-80ff30f55997.png)

#### RepeatGroup 클래스 생성

![image](https://user-images.githubusercontent.com/76154390/192446511-d02a3780-aabc-4cfb-ad94-73deebe1d851.png)
